### PR TITLE
test(tables): add full integration tests (valid + invalid cases)

### DIFF
--- a/__tests__/integration/tables/create.test.ts
+++ b/__tests__/integration/tables/create.test.ts
@@ -1,0 +1,89 @@
+// __tests__/integration/tables/create.test.ts
+import { supabase } from "@/lib/supabase/supabaseClient";
+
+describe("Tables CREATE Integration", () => {
+  const testEstablishmentId = "5139eab5-6eaf-462f-bdbc-04257fdf2520";
+
+  const valid_table_number_1 = 1;
+  const valid_table_number_2 = 2;
+  const negative_table_number = -1;
+
+  // casos validos
+  describe("Valid Cases", () => {
+    it("should create a valid table (1001)", async () => {
+      const { data, error } = await supabase
+        .from("tables")
+        .insert({ table_number: valid_table_number_1, establishment_id: testEstablishmentId })
+        .select()
+        .single();
+
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data.table_number).toBe(valid_table_number_1);
+    });
+
+    it("should create another valid table (1002)", async () => {
+      const { data, error } = await supabase
+        .from("tables")
+        .insert({ table_number: valid_table_number_2, establishment_id: testEstablishmentId })
+        .select()
+        .single();
+
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data.table_number).toBe(valid_table_number_2);
+    });
+  });
+
+  // casos invalidos
+  describe("Invalid Cases", () => {
+    it("should reject negative table_number", async () => {
+      const { data, error } = await supabase
+        .from("tables")
+        .insert({ table_number: negative_table_number, establishment_id: testEstablishmentId })
+        .select()
+        .maybeSingle();
+
+      expect(Boolean(error) || !data).toBe(true);
+    });
+
+    it("should reject table without table_number", async () => {
+      const { data, error } = await supabase
+        .from("tables")
+        .insert({ establishment_id: testEstablishmentId })
+        .select()
+        .maybeSingle();
+
+      expect(Boolean(error) || !data).toBe(true);
+    });
+
+    it("should reject table without establishment_id", async () => {
+      const { data, error } = await supabase
+        .from("tables")
+        .insert({ table_number: 5 })
+        .select()
+        .maybeSingle();
+
+      expect(Boolean(error) || !data).toBe(true);
+    });
+
+    it("should reject table with invalid establishment_id", async () => {
+      const { data, error } = await supabase
+        .from("tables")
+        .insert({ table_number: 3, establishment_id: "00000000-0000-0000-0000-000000000000" })
+        .select()
+        .maybeSingle();
+
+      expect(Boolean(error) || !data).toBe(true);
+    });
+  });
+
+  // limpa os dados inseridos
+  afterAll(async () => {
+    await supabase
+      .from("tables")
+      .delete()
+      .in("table_number", [valid_table_number_1, valid_table_number_2])
+      .eq("establishment_id", testEstablishmentId);
+  });
+});

--- a/__tests__/integration/tables/delete.test.ts
+++ b/__tests__/integration/tables/delete.test.ts
@@ -1,0 +1,86 @@
+import { supabase } from "@/lib/supabase/supabaseClient";
+
+describe("Tables DELETE Integration", () => {
+  const testEstablishmentId = "5139eab5-6eaf-462f-bdbc-04257fdf2520"; // ID de teste
+  let tableToDeleteId: string;
+
+  beforeAll(async () => {
+    // Criar uma mesa válida para deletar depois
+    const { data, error } = await supabase
+      .from("tables")
+      .insert({
+        table_number: 999,
+        establishment_id: testEstablishmentId,
+      })
+      .select()
+      .single();
+
+    if (error) throw new Error(`Setup failed: ${error.message}`);
+    tableToDeleteId = data.id;
+  });
+
+  // Casos válidos
+  describe("Valid Cases", () => {
+    it("should delete an existing table successfully", async () => {
+      const { data, error } = await supabase
+        .from("tables")
+        .delete()
+        .eq("id", tableToDeleteId)
+        .eq("establishment_id", testEstablishmentId)
+        .select()
+        .single();
+
+      expect(error).toBeNull();
+      expect(data?.id).toBe(tableToDeleteId);
+
+      // Verifica se realmente foi deletado
+      const { data: check } = await supabase
+        .from("tables")
+        .select()
+        .eq("id", tableToDeleteId)
+        .maybeSingle();
+
+      expect(check).toBeNull();
+    });
+  });
+
+  // Casos inválidos
+  describe("Invalid Cases", () => {
+    it("should reject deletion of a non-existent table", async () => {
+      const { data, error } = await supabase
+        .from("tables")
+        .delete()
+        .eq("id", "00000000-0000-0000-0000-000000000000")
+        .eq("establishment_id", testEstablishmentId)
+        .select()
+        .maybeSingle();
+
+      expect(Boolean(error) || !data).toBe(true);
+    });
+
+    it("should reject deletion with invalid establishment_id", async () => {
+      // cria uma mesa temporária
+      const { data: temp } = await supabase
+        .from("tables")
+        .insert({
+          table_number: 888,
+          establishment_id: testEstablishmentId,
+        })
+        .select()
+        .single();
+
+      const { data, error } = await supabase
+        .from("tables")
+        .delete()
+        .eq("id", temp.id)
+        .eq("establishment_id", "invalid-establishment")
+        .select()
+        .maybeSingle();
+
+      expect(Boolean(error) || !data).toBe(true);
+
+      // limpa a mesa se ainda existir
+      await supabase.from("tables").delete().eq("id", temp.id);
+    });
+  });
+});

--- a/__tests__/integration/tables/read.test.ts
+++ b/__tests__/integration/tables/read.test.ts
@@ -1,0 +1,32 @@
+import { supabase } from "@/lib/supabase/supabaseClient";
+
+describe("Tables READ Integration", () => {
+  const testEstablishmentId = "5139eab5-6eaf-462f-bdbc-04257fdf2520"; // ID de teste
+
+  // Casos válidos
+  it("should fetch all tables for a valid establishment_id", async () => {
+    const { data, error } = await supabase
+      .from("tables")
+      .select()
+      .eq("establishment_id", testEstablishmentId);
+
+    expect(error).toBeNull();
+    expect(Array.isArray(data)).toBe(true);
+    data?.forEach((table) => {
+      expect(table.establishment_id).toBe(testEstablishmentId);
+      expect(table.table_number).toBeGreaterThan(0);
+    });
+  });
+
+  // Casos inválidos
+  it("should return empty array for non-existent establishment_id", async () => {
+    const { data, error } = await supabase
+      .from("tables")
+      .select()
+      .eq("establishment_id", "00000000-0000-0000-0000-000000000000"); // UUID que não existe
+
+    expect(error).toBeNull();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data?.length).toBe(0);
+  });
+});

--- a/__tests__/integration/tables/update.test.ts
+++ b/__tests__/integration/tables/update.test.ts
@@ -1,0 +1,102 @@
+import { supabase } from "@/lib/supabase/supabaseClient";
+
+describe("Tables UPDATE Integration", () => {
+  const testEstablishmentId = "5139eab5-6eaf-462f-bdbc-04257fdf2520"; // ID de teste
+  const createdTableIds: string[] = [];
+
+  // Casos válidos
+  it("should update a table_number successfully", async () => {
+    const { data: table, error: insertError } = await supabase
+      .from("tables")
+      .insert({ table_number: 1, establishment_id: testEstablishmentId })
+      .select()
+      .single();
+
+    expect(insertError).toBeNull();
+    createdTableIds.push(table.id);
+
+    const { data, error } = await supabase
+      .from("tables")
+      .update({ table_number: 2 })
+      .eq("id", table.id)
+      .eq("establishment_id", testEstablishmentId)
+      .select()
+      .single();
+
+    expect(error).toBeNull();
+    expect(data?.table_number).toBe(2);
+  });
+
+  // Casos inválidos
+  it("should not update if table ID does not exist", async () => {
+    const { data, error } = await supabase
+      .from("tables")
+      .update({ table_number: 9 })
+      .eq("id", "00000000-0000-0000-0000-000000000000")
+      .eq("establishment_id", testEstablishmentId)
+      .select()
+      .maybeSingle();
+
+    expect(Boolean(error) || !data).toBe(true);
+  });
+
+  it("should reject negative table_number", async () => {
+    const { data: table, error: insertError } = await supabase
+      .from("tables")
+      .insert({ table_number: 10, establishment_id: testEstablishmentId })
+      .select()
+      .single();
+
+    expect(insertError).toBeNull();
+    createdTableIds.push(table.id);
+
+    const { data, error } = await supabase
+      .from("tables")
+      .update({ table_number: -5 })
+      .eq("id", table.id)
+      .eq("establishment_id", testEstablishmentId)
+      .select()
+      .maybeSingle();
+
+    expect(Boolean(error) || !data).toBe(true);
+  });
+
+  it("should reject duplicate table_number for the same establishment", async () => {
+    const { data: tables, error: insertError } = await supabase
+      .from("tables")
+      .insert([
+        { table_number: 11, establishment_id: testEstablishmentId },
+        { table_number: 12, establishment_id: testEstablishmentId },
+      ])
+      .select();
+
+    expect(insertError).toBeNull();
+    expect(tables?.length).toBe(2);
+
+    if (!tables || tables.length < 2) {
+      throw new Error("Failed to insert test tables");
+    }
+
+    createdTableIds.push(tables[0].id, tables[1].id);
+
+    const { data, error } = await supabase
+      .from("tables")
+      .update({ table_number: 11 })
+      .eq("id", tables[1].id)
+      .eq("establishment_id", testEstablishmentId)
+      .select()
+      .maybeSingle();
+
+    expect(Boolean(error) || !data).toBe(true);
+  });
+
+  // Limpeza após todos os testes
+  afterAll(async () => {
+    if (createdTableIds.length === 0) return;
+    await supabase
+      .from("tables")
+      .delete()
+      .in("id", createdTableIds)
+      .eq("establishment_id", testEstablishmentId);
+  });
+});


### PR DESCRIPTION
# 🧪 test(tables): add full integration tests (valid + invalid cases)

## 📋 Description
This PR adds **complete integration tests** for the **Tables** module, ensuring full coverage of all CRUD operations (Create, Read, Update, Delete) related to table management in the system.

The tests use the **Supabase Client** configured for the **test database**, covering both **valid** and **invalid** cases to simulate real-world application behavior in a controlled environment.

---

## ✅ Test Cases Included

### **Create**
- Should create a valid table  
- Should create multiple valid tables  
- Should reject a negative `table_number`  
- Should reject a table without `table_number`  
- Should reject a table without `establishment_id`  
- Should reject a table with an invalid `establishment_id`  

### **Read**
- Should fetch all tables by `establishment_id`  
- Should return an empty list when no tables exist  

### **Update**
- Should update a valid table number  
- Should reject update with negative number  
- Should reject update with invalid `id`  
- Should reject duplicate table_number for the same establishment

### **Delete**
- Should delete an existing table  
- Should reject deletion with invalid `id`  

---

## 🧩 Main Changes
- Added `create.test.ts`, `read.test.ts`, `update.test.ts`, and `delete.test.ts` under `integration/tables/`  
- Integrated with `supabaseClient` for the test database  
- Removed dependency on static config (`ESTABLISHMENT_ID` is now set via test constants)  
- Clear separation between **valid** and **invalid** test cases for better organization  