### PR TITLE
fix(menu): correct constraints and add full integration tests

### DIFF
--- a/__tests__/integration/menu/create.test.ts
+++ b/__tests__/integration/menu/create.test.ts
@@ -2,6 +2,7 @@ import { supabase } from "@/lib/supabase/supabaseClient";
 
 describe("Menu CREATE Integration", () => {
   const testCategoryId = "c1d8bc12-dfce-463c-914a-91265b8aaf0b";
+  const testEstablishmentId = "5139eab5-6eaf-462f-bdbc-04257fdf2520";
 
   // Casos válidos
   it("should create a valid menu item", async () => {
@@ -13,6 +14,7 @@ describe("Menu CREATE Integration", () => {
         price: 20,
         category_id: testCategoryId,
         available: true,
+        establishment_id: testEstablishmentId,
       })
       .select()
       .single();
@@ -30,6 +32,7 @@ describe("Menu CREATE Integration", () => {
         price: 0,
         category_id: testCategoryId,
         available: true,
+        establishment_id: testEstablishmentId,
       })
       .select()
       .single();
@@ -47,6 +50,7 @@ describe("Menu CREATE Integration", () => {
         price: -10,
         category_id: testCategoryId,
         available: true,
+        establishment_id: testEstablishmentId,
       })
       .select()
       .maybeSingle();
@@ -61,6 +65,7 @@ describe("Menu CREATE Integration", () => {
         price: 10,
         category_id: testCategoryId,
         available: true,
+        establishment_id: testEstablishmentId,
       })
       .select()
       .maybeSingle();
@@ -75,6 +80,7 @@ describe("Menu CREATE Integration", () => {
         name: "Sem preço",
         category_id: testCategoryId,
         available: true,
+        establishment_id: testEstablishmentId,
       })
       .select()
       .maybeSingle();

--- a/__tests__/integration/menu/delete.test.ts
+++ b/__tests__/integration/menu/delete.test.ts
@@ -2,6 +2,7 @@ import { supabase } from "@/lib/supabase/supabaseClient";
 
 describe("Menu DELETE Integration", () => {
   const testCategoryId = "c1d8bc12-dfce-463c-914a-91265b8aaf0b";
+  const testEstablishmentId = "5139eab5-6eaf-462f-bdbc-04257fdf2520";
   let itemId: string;
 
   beforeAll(async () => {
@@ -12,6 +13,7 @@ describe("Menu DELETE Integration", () => {
         price: 40,
         category_id: testCategoryId,
         available: true,
+        establishment_id: testEstablishmentId,
       })
       .select()
       .single();

--- a/__tests__/integration/menu/read.test.ts
+++ b/__tests__/integration/menu/read.test.ts
@@ -2,6 +2,7 @@ import { supabase } from "@/lib/supabase/supabaseClient";
 
 describe("Menu READ Integration", () => {
   const testCategoryId = "c1d8bc12-dfce-463c-914a-91265b8aaf0b";
+  const testEstablishmentId = "5139eab5-6eaf-462f-bdbc-04257fdf2520";
   let itemId: string;
 
   beforeAll(async () => {
@@ -12,6 +13,7 @@ describe("Menu READ Integration", () => {
         price: 10,
         category_id: testCategoryId,
         available: true,
+        establishment_id: testEstablishmentId,
       })
       .select()
       .single();

--- a/__tests__/integration/menu/update.test.ts
+++ b/__tests__/integration/menu/update.test.ts
@@ -2,6 +2,7 @@ import { supabase } from "@/lib/supabase/supabaseClient";
 
 describe("Menu UPDATE Integration", () => {
   const testCategoryId = "c1d8bc12-dfce-463c-914a-91265b8aaf0b";
+  const testEstablishmentId = "5139eab5-6eaf-462f-bdbc-04257fdf2520";
   let itemId: string;
 
   beforeAll(async () => {
@@ -12,6 +13,7 @@ describe("Menu UPDATE Integration", () => {
         price: 25,
         category_id: testCategoryId,
         available: true,
+        establishment_id: testEstablishmentId,
       })
       .select()
       .single();


### PR DESCRIPTION
#  Menu Module Integration Tests: Fixes

## 🛠 Overview
This update fixes the **Menu module integration tests** to run correctly against the **test database**.  
Previously, some tests were failing due to missing `establishment_id` and invalid constraints.

---

## ✅ Changes Made

### Valid Cases
-  Fixed creation of a valid menu item with proper `category_id` and `establishment_id`.
-  Ensured creation with `price = 0` works as expected.

### Invalid Cases
-  Added database constraint `menu_items_price_positive` to reject negative prices.
-  Fixed tests to properly reject creation without `name`, `price`, or `category_id`.
-  Ensured errors are caught when constraints are violated.

### 💡 Notes
- All tests now run successfully against the Supabase **test environment**.
- Integration tests clearly separate **valid** and **invalid** cases.
- Errors in previous tests caused by null `establishment_id` have been resolved.

