### PR TITLE
Feat/order daily sequence

### DIFF
--- a/app/actions/order-actions.ts
+++ b/app/actions/order-actions.ts
@@ -16,21 +16,11 @@ export interface OrderRequestDTO {
   orderLines: Array<OrderLine>;
   dailySeq?: number;
 }
-
 export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId?: string) {
   const orderEntity = Order.fromDTO(orderDTO);
 
   const supabase = await createClient();
   const establishment_id = testEstablishmentId ? testEstablishmentId : await getEstablishmentId();
-
-  const { data: nextSeq, error: rpcError } = await supabase.rpc('get_next_daily_seq', { 
-    p_establishment_id: establishment_id 
-  });
-
-  if (rpcError) {
-    console.error("Erro ao gerar daily_seq (RPC):", rpcError);
-    throw new Error("Erro ao gerar numeração do pedido.");
-  }
 
   const { data, error } = await supabase
     .from("orders")
@@ -42,7 +32,6 @@ export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId
       detail: orderDTO.detail,
       delivery_fee: orderEntity.type === "DELIVERY" ? (orderEntity as any).deliveryFee : 0,
       estimated_time: orderEntity.estimatedTime ?? 0,
-      daily_seq: nextSeq,
     })
     .select("id, daily_seq")
     .single();

--- a/app/actions/order-actions.ts
+++ b/app/actions/order-actions.ts
@@ -14,12 +14,23 @@ export interface OrderRequestDTO {
   deliveryFee?: number;
   estimatedTime?: number;
   orderLines: Array<OrderLine>;
+  dailySeq?: number;
 }
 
 export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId?: string) {
   const orderEntity = Order.fromDTO(orderDTO);
 
   const supabase = await createClient();
+  const establishment_id = testEstablishmentId ? testEstablishmentId : await getEstablishmentId();
+
+  const { data: nextSeq, error: rpcError } = await supabase.rpc('get_next_daily_seq', { 
+    p_establishment_id: establishment_id 
+  });
+
+  if (rpcError) {
+    console.error("Erro ao gerar daily_seq (RPC):", rpcError);
+    throw new Error("Erro ao gerar numeração do pedido.");
+  }
 
   const { data, error } = await supabase
     .from("orders")
@@ -27,12 +38,13 @@ export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId
       total: orderEntity.total.toFixed(2),
       type: orderEntity.type,
       status: orderEntity.status,
-      establishment_id: testEstablishmentId ? testEstablishmentId : await getEstablishmentId(),
+      establishment_id,
       detail: orderDTO.detail,
       delivery_fee: orderEntity.type === "DELIVERY" ? (orderEntity as any).deliveryFee : 0,
       estimated_time: orderEntity.estimatedTime ?? 0,
+      daily_seq: nextSeq,
     })
-    .select("id")
+    .select("id, daily_seq")
     .single();
 
   if (error) {
@@ -60,13 +72,14 @@ export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId
     }
   }
 
-  const createdOrder = await getOrderById(data.id);
+  orderEntity.id = data.id;
+  orderEntity.dailySeq = data.daily_seq;
 
   if (process.env.TEST_CONTEXT !== "integration") {
     revalidatePath("/orders");
   }
 
-  return createdOrder;
+  return orderEntity.toJSON();
 }
 
 export async function getOrders(establishment_id: string): Promise<any> {
@@ -197,7 +210,7 @@ export async function deleteOrder(id: string): Promise<void> {
   }
 }
 
-export async function updateToClosedOrder(id: string): Promise<void> {
+export async function updateToClosedOrder(id: string): Promise<any> {
   if (!id) throw new Error("ID do pedido inválido.");
 
   const order = Order.fromDTO(await getOrderById(id));
@@ -209,7 +222,7 @@ export async function updateToClosedOrder(id: string): Promise<void> {
     revalidatePath("/orders");
   }
 
-  return adjustOrderLines(order.toJSON());
+  return order.toJSON();
 }
 
 export async function updateToOpenOrder(id: string): Promise<any> {
@@ -224,7 +237,7 @@ export async function updateToOpenOrder(id: string): Promise<any> {
     revalidatePath("/orders");
   }
 
-  return adjustOrderLines(order.toJSON());
+  return order.toJSON();
 }
 
 async function updateOrderStatus(order: Order, id: string) {
@@ -241,6 +254,16 @@ async function updateOrderStatus(order: Order, id: string) {
 }
 
 function adjustOrderLines(orderData: any) {
-  orderData.orderLines = orderData.order_lines
-  return orderData
+  const mappedLines = (orderData.order_lines || []).map((line: any) => ({
+    ...line,
+    menuItemId: line.menu_item_id,
+  }));
+
+  return Order.fromDTO({
+    ...orderData,
+    orderLines: mappedLines,
+    dailySeq: orderData.daily_seq,
+    deliveryFee: orderData.delivery_fee,
+    estimatedTime: orderData.estimated_time,
+  }).toJSON();
 }

--- a/components/molecules/edit-order-modal.tsx
+++ b/components/molecules/edit-order-modal.tsx
@@ -229,7 +229,8 @@ export function EditOrderModal({
                   <div className="space-y-2">
                     <Label>Número da Mesa</Label>
                     <Input
-                      type="number"
+                      type="text"
+                      inputMode="numeric"
                       placeholder="Ex: 5"
                       value={editedDetail}
                       onChange={(e) => setEditedDetail(e.target.value)}

--- a/components/molecules/new-order-form.tsx
+++ b/components/molecules/new-order-form.tsx
@@ -174,7 +174,8 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
               <div className="space-y-2">
                 <Label>Número da Mesa</Label>
                 <Input
-                  type="number"
+                  type="text"
+                  inputMode="numeric"
                   placeholder="Ex: 5"
                   value={orderDetail}
                   onChange={(e) => setOrderDetail(e.target.value)}

--- a/components/organisms/order-card.tsx
+++ b/components/organisms/order-card.tsx
@@ -12,7 +12,7 @@ export function OrderCard({ order, onEdit, onDelete, onFinish, onReopen }: Order
       <div className="flex justify-between items-start mb-2">
         <div>
           <span className="text-xs font-bold text-blue-600 bg-blue-50 px-2 py-1 rounded">
-            #{order.code}
+          {order.code}
           </span>
           <p className="text-sm font-semibold text-gray-800 mt-2">
             {order.type === "LOCAL" ? `Mesa: ${order.detail}` : `Cliente: ${order.detail}`}

--- a/lib/entities/order.ts
+++ b/lib/entities/order.ts
@@ -16,7 +16,8 @@ export abstract class Order {
   orderLines: OrderLine[];
   date?: string;
   estimatedTime?: number;
-  detail?: string
+  detail?: string;
+  dailySeq?: number;
 
   constructor(data: {
     id?: string;
@@ -24,12 +25,14 @@ export abstract class Order {
     orderLines: OrderLine[];
     date?: string;
     estimatedTime?: number;
+    dailySeq?: number;
   }) {
     this.id = data.id;
     this.status = data.status || "OPEN";
     this.orderLines = data.orderLines;
     this.date = data.date || new Date().toISOString();
     this.estimatedTime = data.estimatedTime;
+    this.dailySeq = data.dailySeq;
     this.validateBase();
   }
 
@@ -43,6 +46,9 @@ export abstract class Order {
   }
 
   get code(): string {
+    if (this.dailySeq) {
+      return `#${this.dailySeq}`;
+    }
     if (!this.id) return "";
     let prefix = "";
     switch (this.type) {
@@ -95,6 +101,7 @@ export abstract class Order {
       total: this.total,
       code: this.code,
       itemsCount: this.itemsCount,
+      dailySeq: this.dailySeq,
     };
   }
 
@@ -107,6 +114,7 @@ export abstract class Order {
     address?: string;
     estimatedTime?: number;
     orderLines: OrderLine[];
+    dailySeq?: number;
   }): Order {
     switch (dto.type) {
       case "LOCAL":
@@ -116,6 +124,7 @@ export abstract class Order {
           orderLines: dto.orderLines,
           tableNumber: dto.detail || "",
           estimatedTime: dto.estimatedTime,
+          dailySeq: dto.dailySeq,
         });
       case "PICKUP":
         return new PickupOrder({
@@ -124,6 +133,7 @@ export abstract class Order {
           orderLines: dto.orderLines,
           customerName: dto.detail || "",
           estimatedTime: dto.estimatedTime,
+          dailySeq: dto.dailySeq,
         });
       case "DELIVERY":
         return new DeliveryOrder({
@@ -133,6 +143,7 @@ export abstract class Order {
           address: dto.address || dto.detail || "",
           deliveryFee: dto.deliveryFee || 0,
           estimatedTime: dto.estimatedTime,
+          dailySeq: dto.dailySeq,
         });
       default:
         throw new Error("Tipo de pedido inválido.");
@@ -150,6 +161,7 @@ export class LocalOrder extends Order {
     tableNumber: string;
     date?: string;
     estimatedTime?: number;
+    dailySeq?: number;
   }) {
     super(data);
     this.tableNumber = data.tableNumber;
@@ -177,6 +189,7 @@ export class PickupOrder extends Order {
     customerName: string;
     date?: string;
     estimatedTime?: number;
+    dailySeq?: number;
   }) {
     super(data);
     this.customerName = data.customerName;
@@ -208,6 +221,7 @@ export class DeliveryOrder extends Order {
     deliveryFee: number;
     date?: string;
     estimatedTime?: number;
+    dailySeq?: number;
   }) {
     super(data);
     this.address = data.address;

--- a/lib/entities/order.ts
+++ b/lib/entities/order.ts
@@ -26,6 +26,7 @@ export abstract class Order {
     date?: string;
     estimatedTime?: number;
     dailySeq?: number;
+    detail?: string;
   }) {
     this.id = data.id;
     this.status = data.status || "OPEN";
@@ -33,6 +34,7 @@ export abstract class Order {
     this.date = data.date || new Date().toISOString();
     this.estimatedTime = data.estimatedTime;
     this.dailySeq = data.dailySeq;
+    this.detail = data.detail;
     this.validateBase();
   }
 
@@ -47,7 +49,7 @@ export abstract class Order {
 
   get code(): string {
     if (this.dailySeq) {
-      return `#${this.dailySeq}`;
+      return `${this.dailySeq}`;
     }
     if (!this.id) return "";
     let prefix = "";
@@ -62,7 +64,7 @@ export abstract class Order {
         prefix = "PIC";
         break;
     }
-    return `#${prefix}-${this.id.slice(0, 6).toUpperCase()}`;
+    return `${prefix}-${this.id.slice(0, 6).toUpperCase()}`;
   }
 
   get itemsCount(): number {
@@ -163,7 +165,7 @@ export class LocalOrder extends Order {
     estimatedTime?: number;
     dailySeq?: number;
   }) {
-    super(data);
+    super({ ...data, detail: data.tableNumber });
     this.tableNumber = data.tableNumber;
     this.validate();
   }
@@ -191,7 +193,7 @@ export class PickupOrder extends Order {
     estimatedTime?: number;
     dailySeq?: number;
   }) {
-    super(data);
+    super({ ...data, detail: data.customerName });
     this.customerName = data.customerName;
     this.validate();
   }
@@ -223,7 +225,7 @@ export class DeliveryOrder extends Order {
     estimatedTime?: number;
     dailySeq?: number;
   }) {
-    super(data);
+    super({ ...data, detail: data.address });
     this.address = data.address;
     this.deliveryFee = data.deliveryFee;
     this.validate();

--- a/lib/entities/order.ts
+++ b/lib/entities/order.ts
@@ -49,22 +49,10 @@ export abstract class Order {
 
   get code(): string {
     if (this.dailySeq) {
-      return `${this.dailySeq}`;
+      return `#${this.dailySeq}`;
     }
     if (!this.id) return "";
-    let prefix = "";
-    switch (this.type) {
-      case "LOCAL":
-        prefix = "LOC";
-        break;
-      case "DELIVERY":
-        prefix = "DLV";
-        break;
-      case "PICKUP":
-        prefix = "PIC";
-        break;
-    }
-    return `${prefix}-${this.id.slice(0, 6).toUpperCase()}`;
+    return `#${this.id.slice(0, 6).toUpperCase()}`;
   }
 
   get itemsCount(): number {

--- a/tests/integration/orders/sequence.test.ts
+++ b/tests/integration/orders/sequence.test.ts
@@ -1,0 +1,93 @@
+import { createOrder, OrderRequestDTO } from "@/app/actions/order-actions";
+import { signupService } from "@/app/actions/auth-actions";
+import { SignUpUser } from "@/lib/entities/sign-up-user";
+import { createClient } from "@/utils/supabase/server";
+
+describe("Orders Sequence - Advanced Integration", () => {
+  const testEstablishmentId = process.env.TEST_ESTABLISHMENT_ID!;
+  const mockMenuItemId = "6cfd93ee-1e3d-430d-b525-f5a30bc96338";
+  const supabase = createClient();
+  
+  let otherEstablishmentId: string = "";
+  let otherUserId: string = "";
+
+  const baseOrder: OrderRequestDTO = {
+    total: 10,
+    type: "PICKUP",
+    detail: "Test Client",
+    orderLines: [{ menuItemId: mockMenuItemId, name: "Item", quantity: 1, price: 10 }]
+  };
+
+  beforeAll(async () => {
+    const email = `test_sequence_${Date.now()}@email.com`;
+    const user = new SignUpUser("Second Store", email, "Password123", "Password123");
+    const signupResult = await signupService(user);
+    
+    if (!signupResult.user) throw new Error("Falha ao criar usuário de teste");
+    otherUserId = signupResult.user.id;
+
+    const s = await supabase;
+    const { data: est } = await s.from("establishments").select("id").eq("owner_id", otherUserId).single();
+    
+    if (!est) throw new Error("Estabelecimento de teste não encontrado");
+    otherEstablishmentId = est.id;
+  });
+
+  beforeEach(async () => {
+    const s = await supabase;
+    await s.from("orders").delete().eq("establishment_id", testEstablishmentId);
+    await s.from("daily_counters").delete().eq("establishment_id", testEstablishmentId);
+    
+    if (otherEstablishmentId) {
+      await s.from("orders").delete().eq("establishment_id", otherEstablishmentId);
+      await s.from("daily_counters").delete().eq("establishment_id", otherEstablishmentId);
+    }
+  });
+
+  describe("Positive Scenarios", () => {
+    it("should maintain independent sequences for different establishments", async () => {
+      // Restaurante A -> Pedido #1
+      const orderA1 = await createOrder(baseOrder, testEstablishmentId);
+      expect(orderA1.dailySeq).toBe(1);
+
+      // Restaurante B -> Pedido #1 (Deve ser independente)
+      const orderB1 = await createOrder(baseOrder, otherEstablishmentId);
+      expect(orderB1.dailySeq).toBe(1);
+
+      // Restaurante A -> Pedido #2
+      const orderA2 = await createOrder(baseOrder, testEstablishmentId);
+      expect(orderA2.dailySeq).toBe(2);
+    });
+
+    it("should handle high concurrency without duplication", async () => {
+      const results = await Promise.all([
+        createOrder(baseOrder, testEstablishmentId),
+        createOrder(baseOrder, testEstablishmentId),
+        createOrder(baseOrder, testEstablishmentId),
+      ]);
+      const sequences = results.map(r => r.dailySeq).sort((a, b) => (a ?? 0) - (b ?? 0));
+      expect(sequences).toEqual([1, 2, 3]);
+    });
+
+    it("should NOT reuse numbers if the last order is deleted", async () => {
+      await createOrder(baseOrder, testEstablishmentId); // #1
+      const order2 = await createOrder(baseOrder, testEstablishmentId); // #2
+      
+      const s = await supabase;
+      await s.from("orders").delete().eq("id", order2.id);
+
+      const orderNext = await createOrder(baseOrder, testEstablishmentId);
+      expect(orderNext.dailySeq).toBe(3); 
+    });
+  });
+
+  afterAll(async () => {
+    const s = await supabase;
+    await s.from("orders").delete().eq("establishment_id", testEstablishmentId);
+    await s.from("daily_counters").delete().eq("establishment_id", testEstablishmentId);
+    
+    if (otherUserId) {
+      await s.auth.admin.deleteUser(otherUserId);
+    }
+  });
+});

--- a/tests/unit/entities/order.test.ts
+++ b/tests/unit/entities/order.test.ts
@@ -13,7 +13,7 @@ describe("Order Entity Hierarchy", () => {
         orderLines: commonLines,
       });
       expect(order.type).toBe("LOCAL");
-      expect(order.code).toBe("#LOC-123456");
+      expect(order.code).toBe("#123456");
       expect(order.tableNumber).toBe("5");
     });
 
@@ -34,7 +34,7 @@ describe("Order Entity Hierarchy", () => {
         orderLines: commonLines,
       });
       expect(order.type).toBe("PICKUP");
-      expect(order.code).toBe("#PIC-987654");
+      expect(order.code).toBe("#987654");
       expect(order.customerName).toBe("Tiago");
     });
 
@@ -56,7 +56,7 @@ describe("Order Entity Hierarchy", () => {
         orderLines: commonLines,
       });
       expect(order.type).toBe("DELIVERY");
-      expect(order.code).toBe("#DLV-555666");
+      expect(order.code).toBe("#555666");
       expect(order.total).toBe(60); // 50 + 10
     });
 


### PR DESCRIPTION
  O que foi feito?
  Implementada a numeração sequencial de pedidos que reinicia todo dia para cada restaurante, conforme
  solicitado pela cliente. O formato antigo (LOC-UUID) foi substituído por um número limpo (ex: #1).

  Mudanças principais
   * Banco de Dados: Criada tabela de contadores e um Gatilho (Trigger) para garantir que os números sejam
     gerados sem duplicidade, mesmo em pedidos simultâneos.
   * Entidade Order: Novo formato de código #número e remoção dos prefixos LOC, PIC e DLV.
   * Correções: 
       * Resolvido erro de undefined no número da mesa/nome do cliente.
       * Corrigido bug onde o scroll do mouse alterava o número da mesa no formulário.
   * Testes: Adicionados testes de integração que validam a sequência e a segurança contra pedidos
     duplicados.