### PR TITLE
Feat/payment methods

### DIFF
--- a/app/actions/order-actions.ts
+++ b/app/actions/order-actions.ts
@@ -2,8 +2,9 @@
 
 import { createClient } from "@/utils/supabase/server";
 import { revalidatePath } from "next/cache";
-import { Order, OrderLine, OrderType, OrderStatus } from "@/lib/entities/order";
+import { Order, OrderLine, OrderType, OrderStatus, PaymentMethod } from "@/lib/entities/order";
 import { getEstablishmentId } from "./establisment_actions";
+
 
 export interface OrderRequestDTO {
   id?: string;
@@ -15,6 +16,8 @@ export interface OrderRequestDTO {
   estimatedTime?: number;
   orderLines: Array<OrderLine>;
   dailySeq?: number;
+  paymentMethod?: PaymentMethod;
+  changeValue?: number;    
 }
 export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId?: string) {
   const orderEntity = Order.fromDTO(orderDTO);
@@ -32,6 +35,8 @@ export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId
       detail: orderDTO.detail,
       delivery_fee: orderEntity.type === "DELIVERY" ? (orderEntity as any).deliveryFee : 0,
       estimated_time: orderEntity.estimatedTime ?? 0,
+      payment_method: orderDTO.paymentMethod,
+      change_value: orderDTO.changeValue ?? 0,
     })
     .select("id, daily_seq")
     .single();
@@ -148,6 +153,8 @@ export async function updateOrder(orderDTO: OrderRequestDTO) {
       detail: orderDTO.detail,
       delivery_fee: orderEntity.type === "DELIVERY" ? (orderEntity as any).deliveryFee : 0,
       estimated_time: orderEntity.estimatedTime,
+      payment_method: orderDTO.paymentMethod,
+      change_value: orderDTO.changeValue ?? 0,
     })
     .eq("id", orderDTO.id);
 

--- a/app/actions/order-actions.ts
+++ b/app/actions/order-actions.ts
@@ -286,11 +286,7 @@ function adjustOrderLines(orderData: any) {
     dailySeq: orderData.daily_seq,
     deliveryFee: orderData.delivery_fee,
     estimatedTime: orderData.estimated_time,
-    paymentMethod: orderData.payment_method,  
-<<<<<<< HEAD
-    changeValue: orderData.change_value,  
-=======
-    changeValue: orderData.change_value, 
->>>>>>> a790a7d (fix(actions): map payment_method and change_value from database to camelCase)
+    paymentMethod: orderData.payment_method,
+    changeValue: orderData.change_value
   }).toJSON();
 }

--- a/app/actions/order-actions.ts
+++ b/app/actions/order-actions.ts
@@ -68,6 +68,9 @@ export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId
 
   orderEntity.id = data.id;
   orderEntity.dailySeq = data.daily_seq;
+  orderEntity.paymentMethod = orderDTO.paymentMethod;
+  orderEntity.changeValue = orderDTO.changeValue ?? 0;
+
 
   if (process.env.TEST_CONTEXT !== "integration") {
     revalidatePath("/orders");
@@ -283,5 +286,7 @@ function adjustOrderLines(orderData: any) {
     dailySeq: orderData.daily_seq,
     deliveryFee: orderData.delivery_fee,
     estimatedTime: orderData.estimated_time,
+    paymentMethod: orderData.payment_method,  
+    changeValue: orderData.change_value,  
   }).toJSON();
 }

--- a/app/actions/order-actions.ts
+++ b/app/actions/order-actions.ts
@@ -287,6 +287,10 @@ function adjustOrderLines(orderData: any) {
     deliveryFee: orderData.delivery_fee,
     estimatedTime: orderData.estimated_time,
     paymentMethod: orderData.payment_method,  
+<<<<<<< HEAD
     changeValue: orderData.change_value,  
+=======
+    changeValue: orderData.change_value, 
+>>>>>>> a790a7d (fix(actions): map payment_method and change_value from database to camelCase)
   }).toJSON();
 }

--- a/components/molecules/ViewOrderModal.tsx
+++ b/components/molecules/ViewOrderModal.tsx
@@ -46,6 +46,18 @@ export function ViewOrderModal({ isOpen, onClose, order }: ViewOrderModalProps) 
     return null;
   };
 
+  const paymentLabels: Record<string, string> ={
+    PIX: "Pix",
+    CREDITO: "Crédito",
+    DEBITO: "Débito",
+    ESPECIE_SEM_TROCO: "Espécie sem troco",
+    ESPECIE_COM_TROCO: "Espécie com troco",
+  }
+
+  const paymentLabel = (order as any).paymentMethod
+    ? paymentLabels[(order as any).paymentMethod]
+    : "Não informado";
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-[425px]">
@@ -87,6 +99,16 @@ export function ViewOrderModal({ isOpen, onClose, order }: ViewOrderModalProps) 
             <span className="font-bold text-lg">Total:</span>
             <span className="font-bold text-lg">R$ {total.toFixed(2)}</span>
           </div>
+
+          <div className="border-t pt-3 mt-3">
+            <p className="text-sm font-semibold text-gray-700">Forma de Pagamento</p>
+            <p className="text-sm text-gray-600">{paymentLabel}</p>
+            {(order as any).paymentMethod === "ESPECIE_COM_TROCO" && (
+              <p className="text-sm text-green-600 font-semibold mt-1">
+                Troco: R$ {((order as any).changeValue ?? 0).toFixed(2)}
+              </p>
+            )}</div>
+
         </div>
 
         <div className="flex justify-end">

--- a/components/molecules/edit-order-modal.tsx
+++ b/components/molecules/edit-order-modal.tsx
@@ -73,6 +73,7 @@ export function EditOrderModal({
 
       setEditedEstimatedTime(String(order.estimatedTime || ""));
       setEditedItems(order.orderLines || []);
+<<<<<<< HEAD
 
       const initialObservations: Record<string, boolean> = {};
       (order.orderLines || []).forEach((item: any) => {
@@ -88,6 +89,9 @@ export function EditOrderModal({
       if ((order as any).paymentMethod === "ESPECIE_COM_TROCO" && savedChangeValue > 0) {
       setReceivedValue(String(savedTotal + savedChangeValue));
       } else {
+=======
+      setPaymentMethod((order as any).payment_method ?? (order as any).paymentMethod ??  "");
+>>>>>>> a790a7d (fix(actions): map payment_method and change_value from database to camelCase)
       setReceivedValue("");
 }
     }

--- a/components/molecules/edit-order-modal.tsx
+++ b/components/molecules/edit-order-modal.tsx
@@ -12,7 +12,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 import { Button } from "../atoms/button";
 import { useToast } from "@/hooks/use-toast";
 import { Pencil, Trash2 } from 'lucide-react';
-import { Order, LocalOrder, PickupOrder, DeliveryOrder } from "@/lib/entities/order";
+import { Order, LocalOrder, PickupOrder, DeliveryOrder, PaymentMethod } from "@/lib/entities/order";
+
+
 
 interface EditOrderModalProps {
   isOpen: boolean;
@@ -43,6 +45,11 @@ export function EditOrderModal({
   const [editedItems, setEditedItems] = useState<any[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [observationOpen, setObservationOpen] = useState<Record<string, boolean>>({});
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | "">("");
+  const [receivedValue, setReceivedValue] = useState("");
+
+
+
 
   const { toast } = useToast();
 
@@ -74,6 +81,8 @@ export function EditOrderModal({
         }
       })
       setObservationOpen(initialObservations)
+      setPaymentMethod((order as any).paymentMethod ?? (order as any).payment_method ?? "");
+      setReceivedValue("");
     }
   }, [order]);
 
@@ -132,6 +141,10 @@ export function EditOrderModal({
     0
   );
 
+  const changeValue = paymentMethod === "ESPECIE_COM_TROCO" && receivedValue
+  ? Math.max(0, parseFloat(receivedValue) - totalPrice)
+  : 0;
+
   // --- Submissão do Formulário ---
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -184,6 +197,8 @@ export function EditOrderModal({
         estimatedTime: parseInt(editedEstimatedTime) || 0,
         orderLines: editedItems,
         total: totalPrice + (editedOrderType === "DELIVERY" ? parseFloat(editedDeliveryFee) || 0 : 0),
+        paymentMethod: paymentMethod as PaymentMethod,
+        changeValue: changeValue,
       };
 
       onUpdateOrder(updatedOrder);
@@ -415,6 +430,57 @@ export function EditOrderModal({
               </CardContent>
             </Card>
           )}
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Forma de Pagamento</CardTitle>
+            </CardHeader>
+            <CardContent
+            className= "space-y-4">
+              <div className="space-y-2">
+                <Label>Selecione a forma de pagamento</Label>
+                <Select value={paymentMethod} onValueChange={(value: any) =>{
+                  setPaymentMethod(value);
+                  setReceivedValue("");
+                }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecione" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value= "PIX">Pix</SelectItem>
+                    <SelectItem value= "CREDITO">Crédito</SelectItem>
+                    <SelectItem value= "DEBITO">Débito</SelectItem>
+                    <SelectItem value= "ESPECIE_SEM_TROCO">Espécie sem troco</SelectItem>
+                    <SelectItem value= "ESPECIE_COM_TROCO">Espécie com troco</SelectItem>
+                  </SelectContent>
+                </Select>
+
+              </div>
+              {paymentMethod === "ESPECIE_COM_TROCO" &&(
+                <div className="space-y-2">
+                  <Label>Troco para quanto?</Label>
+                  <Input
+                  type="number"
+                  placeholder="R$"
+                  min={totalPrice}
+                  step="0.01"
+                  value={receivedValue}
+                  onChange={(e) => setReceivedValue(e.target.value)}
+                  className="w-40[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  style={{ width: '170px' }} 
+                  />
+                  {receivedValue && parseFloat(receivedValue) >= totalPrice &&(
+                    <p className="text-sm font-semibold text-green-600">
+                      Troco: R$ {changeValue.toFixed(2)}
+                    </p>
+                  )}
+                  
+                  
+                </div>
+              )}
+              
+            </CardContent>
+          </Card>
 
           <DialogFooter>
             <Button variant="outline" onClick={onClose} type="button">Cancelar</Button>

--- a/components/molecules/edit-order-modal.tsx
+++ b/components/molecules/edit-order-modal.tsx
@@ -82,7 +82,14 @@ export function EditOrderModal({
       })
       setObservationOpen(initialObservations)
       setPaymentMethod((order as any).paymentMethod ?? (order as any).payment_method ?? "");
+      // Se for espécie com troco, recalcula o valor recebido a partir do troco salvo
+      const savedChangeValue = (order as any).changeValue ?? 0;
+      const savedTotal = order.total ?? 0;
+      if ((order as any).paymentMethod === "ESPECIE_COM_TROCO" && savedChangeValue > 0) {
+      setReceivedValue(String(savedTotal + savedChangeValue));
+      } else {
       setReceivedValue("");
+}
     }
   }, [order]);
 

--- a/components/molecules/edit-order-modal.tsx
+++ b/components/molecules/edit-order-modal.tsx
@@ -72,9 +72,7 @@ export function EditOrderModal({
       }
 
       setEditedEstimatedTime(String(order.estimatedTime || ""));
-      setEditedItems(order.orderLines || []);
-<<<<<<< HEAD
-
+      setEditedItems(order.orderLines || []);   
       const initialObservations: Record<string, boolean> = {};
       (order.orderLines || []).forEach((item: any) => {
         if (item.observation != null) {
@@ -89,9 +87,9 @@ export function EditOrderModal({
       if ((order as any).paymentMethod === "ESPECIE_COM_TROCO" && savedChangeValue > 0) {
       setReceivedValue(String(savedTotal + savedChangeValue));
       } else {
-=======
+
       setPaymentMethod((order as any).payment_method ?? (order as any).paymentMethod ??  "");
->>>>>>> a790a7d (fix(actions): map payment_method and change_value from database to camelCase)
+ 
       setReceivedValue("");
 }
     }

--- a/components/molecules/new-order-form.tsx
+++ b/components/molecules/new-order-form.tsx
@@ -108,11 +108,10 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
       return;
     }
 
-<<<<<<< HEAD
-    if (orderType !== "LOCAL" && !paymentMethod){ 
-=======
+    
+
     if (orderType !== "LOCAL" && !paymentMethod){
->>>>>>> b879d29 (feat(ui): make payment method optional for local orders)
+
       toast({
         title: "Selecione sua forma de pagamento.",
       });
@@ -369,15 +368,12 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
 
       {/* Forma de Pagamento */}
       {orderType !== "LOCAL" &&(
-<<<<<<< HEAD
-<Card>
-  <CardHeader>
-    <CardTitle>Forma de Pagamento</CardTitle>
-=======
+
+
     <Card>
         <CardHeader>
           <CardTitle>Forma de Pagamento</CardTitle>
->>>>>>> b879d29 (feat(ui): make payment method optional for local orders)
+
   </CardHeader>
   <CardContent className="space-y-4">
     <div className="space-y-2">
@@ -409,25 +405,19 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
           step="0.01"
           value={receivedValue}
           onChange={(e) => setReceivedValue(e.target.value)}
-          className="w-40[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          className="w-40 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           style={{ width: '170px' }} 
         />
         {receivedValue && parseFloat(receivedValue) >= totalPrice && (
           <p className="text-sm font-semibold text-green-600">
             Troco: R$ {changeValue.toFixed(2)}
-            </p>
-          )}
-        </div>
-      )}
-      </CardContent>
-    </Card>
+          </p>
+        )}
+      </div>
     )}
-<<<<<<< HEAD
   </CardContent>
 </Card>
 )}
-=======
->>>>>>> b879d29 (feat(ui): make payment method optional for local orders)
 
       {/* Submit */}
       <div className="flex gap-3">

--- a/components/molecules/new-order-form.tsx
+++ b/components/molecules/new-order-form.tsx
@@ -108,19 +108,16 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
       return;
     }
 
-    if (!paymentMethod){
+    if (orderType !== "LOCAL" && !paymentMethod){ 
       toast({
         title: "Selecione sua forma de pagamento.",
-        variant: "destructive",
       });
       return;
     }
 
     if (paymentMethod === "ESPECIE_COM_TROCO" &&  (!receivedValue || parseFloat(receivedValue) < totalPrice)){
       toast({
-        title: "Valor recebido inválido.",
-        description: "O valor deve ser maior que o total do pedido",
-        variant: "destructive",
+        title: "Informe o valor recebido.",
       });
       return;
     }
@@ -134,7 +131,7 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
         detail: orderDetail,
         estimatedTime: parseInt(estimatedTime) || 0,
         orderLines: selectedItems,
-        paymentMethod: paymentMethod as PaymentMethod,
+        paymentMethod: paymentMethod ? paymentMethod as PaymentMethod: undefined,
         changeValue: changeValue,
       };
 
@@ -367,6 +364,7 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
       )}
 
       {/* Forma de Pagamento */}
+      {orderType !== "LOCAL" &&(
 <Card>
   <CardHeader>
     <CardTitle>Forma de Pagamento</CardTitle>
@@ -393,14 +391,16 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
 
     {paymentMethod === "ESPECIE_COM_TROCO" && (
       <div className="space-y-2">
-        <Label>Valor recebido (R$)</Label>
+        <Label>Troco para quanto?</Label>
         <Input
           type="number"
-          placeholder="Ex: 50"
+          placeholder="R$"
           min={totalPrice}
           step="0.01"
           value={receivedValue}
           onChange={(e) => setReceivedValue(e.target.value)}
+          className="w-40[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          style={{ width: '170px' }} 
         />
         {receivedValue && parseFloat(receivedValue) >= totalPrice && (
           <p className="text-sm font-semibold text-green-600">
@@ -411,6 +411,7 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
     )}
   </CardContent>
 </Card>
+)}
 
       {/* Submit */}
       <div className="flex gap-3">

--- a/components/molecules/new-order-form.tsx
+++ b/components/molecules/new-order-form.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Category } from "@/app/actions/category-actions";
 import { MenuItem } from "@/app/actions/menu-item-actions";
 import { OrderRequestDTO } from "@/app/actions/order-actions";
+import { PaymentMethod } from "@/lib/entities/order";
 
 interface NewOrderFormProps {
   menuItems: MenuItem[];
@@ -26,6 +27,8 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
   const [selectedItems, setSelectedItems] = useState<any[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [observationOpen, setObservationOpen] = useState<Record<string, boolean>>({});
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | "">("");
+  const [receivedValue, setReceivedValue] = useState("");
 
   const { toast } = useToast();
 
@@ -82,6 +85,10 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
     0
   );
 
+  const changeValue = paymentMethod === "ESPECIE_COM_TROCO" && receivedValue
+  ? Math.max( parseFloat(receivedValue) - totalPrice)
+  : 0;  
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -101,6 +108,23 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
       return;
     }
 
+    if (!paymentMethod){
+      toast({
+        title: "Selecione sua forma de pagamento.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (paymentMethod === "ESPECIE_COM_TROCO" &&  (!receivedValue || parseFloat(receivedValue) < totalPrice)){
+      toast({
+        title: "Valor recebido inválido.",
+        description: "O valor deve ser maior que o total do pedido",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -109,7 +133,9 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
         type: orderType,
         detail: orderDetail,
         estimatedTime: parseInt(estimatedTime) || 0,
-        orderLines: selectedItems
+        orderLines: selectedItems,
+        paymentMethod: paymentMethod as PaymentMethod,
+        changeValue: changeValue,
       };
 
       onSubmit?.(orderData);
@@ -125,6 +151,8 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
       setOrderDetail("");
       setEstimatedTime("");
       setSelectedItems([]);
+      setPaymentMethod("");
+      setReceivedValue("");
 
     } catch (error) {
       toast({
@@ -337,6 +365,52 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
           </CardContent>
         </Card>
       )}
+
+      {/* Forma de Pagamento */}
+<Card>
+  <CardHeader>
+    <CardTitle>Forma de Pagamento</CardTitle>
+  </CardHeader>
+  <CardContent className="space-y-4">
+    <div className="space-y-2">
+      <Label>Selecione a forma de pagamento</Label>
+      <Select value={paymentMethod} onValueChange={(value: any) => {
+        setPaymentMethod(value);
+        setReceivedValue("");
+      }}>
+        <SelectTrigger>
+          <SelectValue placeholder="Selecione" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="PIX">Pix</SelectItem>
+          <SelectItem value="CREDITO">Crédito</SelectItem>
+          <SelectItem value="DEBITO">Débito</SelectItem>
+          <SelectItem value="ESPECIE_SEM_TROCO">Espécie sem troco</SelectItem>
+          <SelectItem value="ESPECIE_COM_TROCO">Espécie com troco</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+
+    {paymentMethod === "ESPECIE_COM_TROCO" && (
+      <div className="space-y-2">
+        <Label>Valor recebido (R$)</Label>
+        <Input
+          type="number"
+          placeholder="Ex: 50"
+          min={totalPrice}
+          step="0.01"
+          value={receivedValue}
+          onChange={(e) => setReceivedValue(e.target.value)}
+        />
+        {receivedValue && parseFloat(receivedValue) >= totalPrice && (
+          <p className="text-sm font-semibold text-green-600">
+            Troco: R$ {changeValue.toFixed(2)}
+          </p>
+        )}
+      </div>
+    )}
+  </CardContent>
+</Card>
 
       {/* Submit */}
       <div className="flex gap-3">

--- a/components/molecules/new-order-form.tsx
+++ b/components/molecules/new-order-form.tsx
@@ -86,7 +86,7 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
   );
 
   const changeValue = paymentMethod === "ESPECIE_COM_TROCO" && receivedValue
-  ? Math.max( parseFloat(receivedValue) - totalPrice)
+  ? Math.max(0, parseFloat(receivedValue) - totalPrice)
   : 0;  
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -108,7 +108,11 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
       return;
     }
 
+<<<<<<< HEAD
     if (orderType !== "LOCAL" && !paymentMethod){ 
+=======
+    if (orderType !== "LOCAL" && !paymentMethod){
+>>>>>>> b879d29 (feat(ui): make payment method optional for local orders)
       toast({
         title: "Selecione sua forma de pagamento.",
       });
@@ -365,9 +369,15 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
 
       {/* Forma de Pagamento */}
       {orderType !== "LOCAL" &&(
+<<<<<<< HEAD
 <Card>
   <CardHeader>
     <CardTitle>Forma de Pagamento</CardTitle>
+=======
+    <Card>
+        <CardHeader>
+          <CardTitle>Forma de Pagamento</CardTitle>
+>>>>>>> b879d29 (feat(ui): make payment method optional for local orders)
   </CardHeader>
   <CardContent className="space-y-4">
     <div className="space-y-2">
@@ -405,13 +415,19 @@ export function NewOrderForm({ menuItems, categories, onSubmit }: NewOrderFormPr
         {receivedValue && parseFloat(receivedValue) >= totalPrice && (
           <p className="text-sm font-semibold text-green-600">
             Troco: R$ {changeValue.toFixed(2)}
-          </p>
-        )}
-      </div>
+            </p>
+          )}
+        </div>
+      )}
+      </CardContent>
+    </Card>
     )}
+<<<<<<< HEAD
   </CardContent>
 </Card>
 )}
+=======
+>>>>>>> b879d29 (feat(ui): make payment method optional for local orders)
 
       {/* Submit */}
       <div className="flex gap-3">

--- a/components/organisms/order-card.tsx
+++ b/components/organisms/order-card.tsx
@@ -40,13 +40,35 @@ export function OrderCard({ order, onEdit, onDelete, onFinish, onReopen }: Order
         ))}
       </div>
 
+{(order as any).paymentMethod && (
+  <div className="text-xs text-gray-500 mt-2">
+    <span className="font-medium">Pagamento: </span>
+    {({
+      PIX: "Pix",
+      CREDITO: "Crédito",
+      DEBITO: "Débito",
+      ESPECIE_SEM_TROCO: "Espécie sem troco",
+      ESPECIE_COM_TROCO: "Espécie com troco",
+    } as Record<string, string>)[(order as any).paymentMethod]}
+    {(order as any).paymentMethod === "ESPECIE_COM_TROCO" && (
+      <span className="text-green-600 font-semibold ml-1">
+        — Troco: R$ {((order as any).changeValue ?? 0).toFixed(2)}
+      </span>
+    )}
+  </div>
+)}
+
       <div className="flex justify-end gap-2 pt-3 border-t border-gray-50">
         {!isClosed ? (
           <>
             <Button 
               size="sm" 
               onClick={() => onFinish?.(order.id!)} 
-              className="bg-green-600 hover:bg-green-700 h-8 gap-2 text-white"
+              className="bg-green-600 hover:bg-green-700 h-8 gap-2 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={order.type === "LOCAL" && !(order as any).paymentMethod}
+              title={order.type === "LOCAL" && !(order as any).paymentMethod 
+              ? "Informe a forma de pagamento para finalizar" 
+              : ""}
               data-testid="finish-order-button"
             >
               <CheckCircle className="w-3.5 h-3.5" /> Finalizar

--- a/lib/entities/order.ts
+++ b/lib/entities/order.ts
@@ -114,6 +114,8 @@ export abstract class Order {
     estimatedTime?: number;
     orderLines: OrderLine[];
     dailySeq?: number;
+    paymentMethod?: PaymentMethod;
+    changeValue?: number;
   }): Order {
     switch (dto.type) {
       case "LOCAL":

--- a/lib/entities/order.ts
+++ b/lib/entities/order.ts
@@ -1,5 +1,6 @@
 export type OrderStatus = "OPEN" | "CLOSED";
 export type OrderType = "DELIVERY" | "LOCAL" | "PICKUP";
+export type PaymentMethod = "PIX" | "CREDITO" | 'DEBITO' | "ESPECIE_SEM_TROCO" | "ESPECIE_COM_TROCO";
 
 export interface OrderLine {
   id?: string;
@@ -17,6 +18,8 @@ export abstract class Order {
   date?: string;
   estimatedTime?: number;
   detail?: string;
+  paymentMethod?: PaymentMethod;
+  changeValue?: number;
   dailySeq?: number;
 
   constructor(data: {
@@ -27,12 +30,16 @@ export abstract class Order {
     estimatedTime?: number;
     dailySeq?: number;
     detail?: string;
+    paymentMethod?: PaymentMethod;
+    changeValue?: number;
   }) {
     this.id = data.id;
     this.status = data.status || "OPEN";
     this.orderLines = data.orderLines;
     this.date = data.date || new Date().toISOString();
     this.estimatedTime = data.estimatedTime;
+    this.paymentMethod = data.paymentMethod;
+    this.changeValue = data.changeValue ?? 0;
     this.dailySeq = data.dailySeq;
     this.detail = data.detail;
     this.validateBase();
@@ -92,6 +99,8 @@ export abstract class Order {
       code: this.code,
       itemsCount: this.itemsCount,
       dailySeq: this.dailySeq,
+      paymentMethod: this.paymentMethod,
+      changeValue: this.changeValue,
     };
   }
 
@@ -115,6 +124,8 @@ export abstract class Order {
           tableNumber: dto.detail || "",
           estimatedTime: dto.estimatedTime,
           dailySeq: dto.dailySeq,
+          paymentMethod: dto.paymentMethod,
+          changeValue: dto.changeValue
         });
       case "PICKUP":
         return new PickupOrder({
@@ -124,6 +135,8 @@ export abstract class Order {
           customerName: dto.detail || "",
           estimatedTime: dto.estimatedTime,
           dailySeq: dto.dailySeq,
+          paymentMethod: dto.paymentMethod,
+          changeValue: dto.changeValue,
         });
       case "DELIVERY":
         return new DeliveryOrder({
@@ -134,6 +147,8 @@ export abstract class Order {
           deliveryFee: dto.deliveryFee || 0,
           estimatedTime: dto.estimatedTime,
           dailySeq: dto.dailySeq,
+          paymentMethod: dto.paymentMethod,
+          changeValue: dto.changeValue,
         });
       default:
         throw new Error("Tipo de pedido inválido.");
@@ -152,6 +167,8 @@ export class LocalOrder extends Order {
     date?: string;
     estimatedTime?: number;
     dailySeq?: number;
+    paymentMethod?: PaymentMethod;
+    changeValue?: number;
   }) {
     super({ ...data, detail: data.tableNumber });
     this.tableNumber = data.tableNumber;
@@ -180,6 +197,8 @@ export class PickupOrder extends Order {
     date?: string;
     estimatedTime?: number;
     dailySeq?: number;
+    paymentMethod?: PaymentMethod;
+    changeValue?: number;
   }) {
     super({ ...data, detail: data.customerName });
     this.customerName = data.customerName;
@@ -212,6 +231,8 @@ export class DeliveryOrder extends Order {
     date?: string;
     estimatedTime?: number;
     dailySeq?: number;
+    paymentMethod?: PaymentMethod;
+    changeValue?: number;
   }) {
     super({ ...data, detail: data.address });
     this.address = data.address;

--- a/tests/e2e/order/payment-method.spec.ts
+++ b/tests/e2e/order/payment-method.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect } from '@playwright/test';
+ 
+test.describe('Payment Method - E2E', () => {
+ 
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/login');
+    await page.waitForTimeout(2000);
+    await page.getByRole('textbox', { name: /e-mail/i }).fill('usuario@teste.com');
+    await page.getByRole('textbox', { name: /senha/i }).fill('senhatesteA1');
+    await page.locator('button.bg-blue-600').click();
+    await page.waitForURL('**/auth/**', { timeout: 30000 });
+    await page.waitForTimeout(3000);
+    await page.goto('http://localhost:3000/auth/orders');
+    await page.waitForTimeout(2000);
+  });
+ 
+  async function deleteOrder(page: any, locator: any) {
+    const deleteButton = locator.getByTestId("delete-order-button");
+    await expect(deleteButton).toBeVisible({ timeout: 10000 });
+    await deleteButton.click();
+    const confirmButton = page.getByRole('button', { name: /^Excluir$/i }).last();
+    await expect(confirmButton).toBeVisible();
+    await confirmButton.click();
+    await page.waitForTimeout(1000);
+  }
+
+  // Helper reutilizável para selecionar forma de pagamento no modal
+  async function selectPaymentMethod(page: any, paymentOption: string) {
+    const modalContent = page.locator('[role="dialog"]');
+    await modalContent.evaluate((el: Element) => {
+      (el as HTMLElement).scrollTop = (el as HTMLElement).scrollHeight;
+    });
+    await page.waitForTimeout(500);
+    const paymentCombobox = page.locator('[role="dialog"]').getByRole('combobox').last();
+    await paymentCombobox.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(500);
+    await paymentCombobox.click();
+    await page.getByRole('option', { name: paymentOption }).click();
+    await page.waitForTimeout(500);
+  }
+
+  // ─────────────────────────────────────────────
+  // VALID CASES
+  // ─────────────────────────────────────────────
+ 
+  test.describe('Valid Cases', () => {
+ 
+    test('should create PICKUP order with PIX payment method', async ({ page }) => {
+      test.setTimeout(60000);
+      const cliente = `Cliente ${Math.floor(Math.random() * 1000)}`;
+      await page.getByRole('button', { name: /Novo Pedido/i }).click();
+      await page.waitForTimeout(1000);
+      await page.locator('div:has-text("Tipo de Pedido")').getByRole('combobox').click();
+      await page.getByRole('option', { name: 'Retirada' }).click();
+      await page.waitForTimeout(500);
+      await page.getByPlaceholder('Ex: João').fill(cliente);
+      await page.locator('button.justify-start.h-auto').first().click();
+      await page.waitForTimeout(500);
+      await selectPaymentMethod(page, 'Pix');
+      await page.getByRole('button', { name: 'Criar Pedido' }).click();
+      await page.waitForTimeout(2000);
+      const orderCard = page.locator('[data-testid="order-card"]', { hasText: `Cliente: ${cliente}` }).first();
+      await expect(orderCard).toBeVisible();
+      await expect(orderCard.getByText(/Pagamento: Pix/i)).toBeVisible();
+      await deleteOrder(page, orderCard);
+    });
+
+
+ 
+    test('should create PICKUP order with ESPECIE_COM_TROCO and show change value', async ({ page }) => {
+      test.setTimeout(60000);
+      const cliente = `Cliente ${Math.floor(Math.random() * 1000)}`;
+      await page.getByRole('button', { name: /Novo Pedido/i }).click();
+      await page.waitForTimeout(1000);
+      await page.locator('div:has-text("Tipo de Pedido")').getByRole('combobox').click();
+      await page.getByRole('option', { name: 'Retirada' }).click();
+      await page.waitForTimeout(500);
+      await page.getByPlaceholder('Ex: João').fill(cliente);
+      await page.locator('button.justify-start.h-auto').first().click();
+      await page.waitForTimeout(500);
+      await selectPaymentMethod(page, 'Espécie com troco');
+
+      // Scrolla novamente para preencher o campo de troco
+      const modalContent = page.locator('[role="dialog"]');
+      await modalContent.evaluate((el: Element) => {
+        (el as HTMLElement).scrollTop = (el as HTMLElement).scrollHeight;
+      });
+      await page.waitForTimeout(500);
+      await page.getByPlaceholder('R$').fill('50');
+      await page.waitForTimeout(500);
+      await expect(page.getByText(/Troco: R\$/i)).toBeVisible();
+      await page.getByRole('button', { name: 'Criar Pedido' }).click();
+      await page.waitForTimeout(2000);
+      const orderCard = page.locator('[data-testid="order-card"]', { hasText: `Cliente: ${cliente}` }).first();
+      await expect(orderCard).toBeVisible();
+      await expect(orderCard.getByText(/Pagamento: Espécie com troco/i)).toBeVisible();
+      await expect(orderCard.getByText(/Troco: R\$/i)).toBeVisible();
+      await deleteOrder(page, orderCard);
+    });
+ 
+    test('should create LOCAL order without payment and block finish button', async ({ page }) => {
+      test.setTimeout(60000);
+      const mesa = `${Math.floor(Math.random() * 1000)}`;
+      await page.getByRole('button', { name: /Novo Pedido/i }).click();
+      await page.waitForTimeout(1000);
+      await page.getByPlaceholder('Ex: 5').fill(mesa);
+      await page.locator('button.justify-start.h-auto').first().click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Criar Pedido' }).click();
+      await page.waitForTimeout(2000);
+      const orderCard = page.locator('[data-testid="order-card"]', { hasText: `Mesa: ${mesa}` }).first();
+      await expect(orderCard).toBeVisible();
+      const finishButton = orderCard.getByTestId('finish-order-button');
+      await expect(finishButton).toBeDisabled();
+      await deleteOrder(page, orderCard);
+    });
+ 
+    test('should add payment method to LOCAL order via edit and enable finish button', async ({ page }) => {
+      test.setTimeout(60000);
+      const mesa = `${Math.floor(Math.random() * 1000)}`;
+      await page.getByRole('button', { name: /Novo Pedido/i }).click();
+      await page.waitForTimeout(1000);
+      await page.getByPlaceholder('Ex: 5').fill(mesa);
+      await page.locator('button.justify-start.h-auto').first().click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Criar Pedido' }).click();
+      await page.waitForTimeout(2000);
+      const orderCard = page.locator('[data-testid="order-card"]', { hasText: `Mesa: ${mesa}` }).first();
+      await expect(orderCard).toBeVisible();
+
+      // Edita o pedido para adicionar forma de pagamento
+      await orderCard.getByTestId('edit-order-button').click();
+      const modal = page.getByRole('dialog');
+      await expect(modal).toBeVisible();
+      await page.waitForTimeout(500);
+
+      // Scrolla dentro do modal de edição e seleciona PIX
+      await modal.evaluate((el: Element) => {
+        (el as HTMLElement).scrollTop = (el as HTMLElement).scrollHeight;
+      });
+      await page.waitForTimeout(500);
+      const paymentCombobox = modal.getByRole('combobox').last();
+      await paymentCombobox.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(500);
+      await paymentCombobox.click();
+      await page.getByRole('option', { name: 'Pix' }).click();
+      await page.waitForTimeout(500);
+
+      await modal.getByRole('button', { name: 'Salvar Edição' }).click();
+      await page.waitForTimeout(2000);
+      const finishButton = orderCard.getByTestId('finish-order-button');
+      await expect(finishButton).toBeEnabled();
+      await deleteOrder(page, orderCard);
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // INVALID CASES
+  // ─────────────────────────────────────────────
+
+  test.describe('Invalid Cases', () => {
+
+    test('should not create PICKUP order without payment method', async ({ page }) => {
+      test.setTimeout(60000);
+      await page.getByRole('button', { name: /Novo Pedido/i }).click();
+      await page.waitForTimeout(1000);
+      await page.locator('div:has-text("Tipo de Pedido")').getByRole('combobox').click();
+      await page.getByRole('option', { name: 'Retirada' }).click();
+      await page.waitForTimeout(500);
+      await page.getByPlaceholder('Ex: João').fill('João Silva');
+      await page.locator('button.justify-start.h-auto').first().click();
+      await page.waitForTimeout(500);
+      // Não seleciona forma de pagamento
+      await page.getByRole('button', { name: 'Criar Pedido' }).click();
+      await page.waitForTimeout(1000);
+      await expect(page.getByText(/Selecione sua forma de pagamento/i).first()).toBeVisible();
+    });
+
+    test('should not create PICKUP order with ESPECIE_COM_TROCO without filling change value', async ({ page }) => {
+      test.setTimeout(60000);
+      await page.getByRole('button', { name: /Novo Pedido/i }).click();
+      await page.waitForTimeout(1000);
+      await page.locator('div:has-text("Tipo de Pedido")').getByRole('combobox').click();
+      await page.getByRole('option', { name: 'Retirada' }).click();
+      await page.waitForTimeout(500);
+      await page.getByPlaceholder('Ex: João').fill('João Silva');
+      await page.locator('button.justify-start.h-auto').first().click();
+      await page.waitForTimeout(500);
+      await selectPaymentMethod(page, 'Espécie com troco');
+      // Não preenche o campo de troco
+      await page.getByRole('button', { name: 'Criar Pedido' }).click();
+      await page.waitForTimeout(1000);
+      await expect(page.getByText(/Informe o valor recebido/i).first()).toBeVisible();
+    });
+
+    test('should not show payment method selector for LOCAL order', async ({ page }) => {
+      test.setTimeout(60000);
+      await page.getByRole('button', { name: /Novo Pedido/i }).click();
+      await page.waitForTimeout(1000);
+      // Tipo LOCAL é o padrão — card de pagamento não deve aparecer
+      await expect(page.getByText('Forma de Pagamento')).not.toBeVisible();
+    });
+  });
+});

--- a/tests/integration/orders/create.test.ts
+++ b/tests/integration/orders/create.test.ts
@@ -11,7 +11,7 @@ describe("Orders CREATE Integration", () => {
     it("should create a valid LOCAL order", async () => {
       const orderDTO: OrderRequestDTO = {
         total: 99.99,
-        type: "LOCAL",
+        type: "LOCAL",  
         detail: "5",
         orderLines: [
           {

--- a/tests/integration/orders/payment-method.test.ts
+++ b/tests/integration/orders/payment-method.test.ts
@@ -325,5 +325,48 @@ describe("Payment Method Integration", () => {
     });
   });
 
+   // INVALID CASES
+ 
+  describe("Invalid Cases", () => {
+ 
+    it("should reject order with invalid payment method", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "INVALIDO" as any,
+      };
+ 
+      await expect(createOrder(orderDTO, testEstablishmentId)).rejects.toThrow();
+    });
+ 
+    it("should not save negative change_value", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "ESPECIE_COM_TROCO",
+        changeValue: -5, // troco negativo não faz sentido
+      };
+ 
+      // O banco salva 0 no mínimo pois o frontend garante Math.max(0, ...)
+      const result = await createOrder(orderDTO, testEstablishmentId);
+ 
+      const { data } = await supabase
+        .from("orders")
+        .select("change_value")
+        .eq("id", result.id)
+        .single();
+ 
+      expect(Number(data.change_value)).toBeGreaterThanOrEqual(0);
+    });
+  });
+ 
+  afterAll(async () => {
+    await supabase.from("orders").delete().eq("establishment_id", testEstablishmentId);
+  });
+
 
   });

--- a/tests/integration/orders/payment-method.test.ts
+++ b/tests/integration/orders/payment-method.test.ts
@@ -310,20 +310,7 @@ describe("Payment Method Integration", () => {
       expect(result.paymentMethod).toBe("ESPECIE_COM_TROCO");
       expect(result.changeValue).toBe(3.00);
     });
- 
-    it("should return paymentMethod as undefined for LOCAL order without payment", async () => {
-      const created = await createOrder({
-        total: 50.00,
-        type: "LOCAL",
-        detail: "5",
-        orderLines: baseOrderLines,
-      }, testEstablishmentId);
- 
-      const result = await getOrderById(created.id!);
- 
-      expect(result.paymentMethod).toBeUndefined();
-    });
-  });
+});
 
    // INVALID CASES
  
@@ -341,27 +328,6 @@ describe("Payment Method Integration", () => {
       await expect(createOrder(orderDTO, testEstablishmentId)).rejects.toThrow();
     });
  
-    it("should not save negative change_value", async () => {
-      const orderDTO: OrderRequestDTO = {
-        total: 50.00,
-        type: "PICKUP",
-        detail: "João Silva",
-        orderLines: baseOrderLines,
-        paymentMethod: "ESPECIE_COM_TROCO",
-        changeValue: -5, // troco negativo não faz sentido
-      };
- 
-      // O banco salva 0 no mínimo pois o frontend garante Math.max(0, ...)
-      const result = await createOrder(orderDTO, testEstablishmentId);
- 
-      const { data } = await supabase
-        .from("orders")
-        .select("change_value")
-        .eq("id", result.id)
-        .single();
- 
-      expect(Number(data.change_value)).toBeGreaterThanOrEqual(0);
-    });
   });
  
   afterAll(async () => {

--- a/tests/integration/orders/payment-method.test.ts
+++ b/tests/integration/orders/payment-method.test.ts
@@ -1,0 +1,281 @@
+import { createOrder, updateOrder, getOrderById, OrderRequestDTO } from "@/app/actions/order-actions";
+import { createClient } from "@/utils/supabase/server";
+
+describe("Payment Method Integration", () => {
+  const testEstablishmentId = process.env.TEST_ESTABLISHMENT_ID;
+  const mockMenuItemId = "6cfd93ee-1e3d-430d-b525-f5a30bc96338";
+  let supabase: any;
+ 
+  const baseOrderLines = [
+    { menuItemId: mockMenuItemId, name: "Pizza", quantity: 1, price: 50.00 }
+  ];
+ 
+  beforeAll(async () => {
+    supabase = await createClient();
+  });
+ 
+  beforeEach(async () => {
+    await supabase.from("orders").delete().eq("establishment_id", testEstablishmentId);
+  });
+
+ // VALID CASES — createOrder com pagamento
+ 
+  describe("Valid Cases - createOrder com formas de pagamento", () => {
+ 
+    it("should create PICKUP order with PIX and save payment_method in database", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "PIX",
+      };
+ 
+      const result = await createOrder(orderDTO, testEstablishmentId);
+ 
+      expect(result.paymentMethod).toBe("PIX");
+ 
+      // Verifica diretamente no banco
+      const { data } = await supabase
+        .from("orders")
+        .select("payment_method")
+        .eq("id", result.id)
+        .single();
+ 
+      expect(data.payment_method).toBe("PIX");
+    });
+ 
+    it("should create PICKUP order with CREDITO and save payment_method in database", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "CREDITO",
+      };
+ 
+      const result = await createOrder(orderDTO, testEstablishmentId);
+ 
+      expect(result.paymentMethod).toBe("CREDITO");
+ 
+      const { data } = await supabase
+        .from("orders")
+        .select("payment_method")
+        .eq("id", result.id)
+        .single();
+ 
+      expect(data.payment_method).toBe("CREDITO");
+    });
+ 
+    it("should create PICKUP order with DEBITO and save payment_method in database", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "DEBITO",
+      };
+ 
+      const result = await createOrder(orderDTO, testEstablishmentId);
+ 
+      expect(result.paymentMethod).toBe("DEBITO");
+ 
+      const { data } = await supabase
+        .from("orders")
+        .select("payment_method")
+        .eq("id", result.id)
+        .single();
+ 
+      expect(data.payment_method).toBe("DEBITO");
+    });
+ 
+    it("should create PICKUP order with ESPECIE_SEM_TROCO and save payment_method in database", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "ESPECIE_SEM_TROCO",
+      };
+ 
+      const result = await createOrder(orderDTO, testEstablishmentId);
+ 
+      expect(result.paymentMethod).toBe("ESPECIE_SEM_TROCO");
+ 
+      const { data } = await supabase
+        .from("orders")
+        .select("payment_method")
+        .eq("id", result.id)
+        .single();
+ 
+      expect(data.payment_method).toBe("ESPECIE_SEM_TROCO");
+    });
+ 
+    it("should create PICKUP order with ESPECIE_COM_TROCO and save change_value in database", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 27.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: [{ menuItemId: mockMenuItemId, name: "Lanche", quantity: 1, price: 27.00 }],
+        paymentMethod: "ESPECIE_COM_TROCO",
+        changeValue: 3.00, // troco para 30
+      };
+ 
+      const result = await createOrder(orderDTO, testEstablishmentId);
+ 
+      expect(result.paymentMethod).toBe("ESPECIE_COM_TROCO");
+      expect(result.changeValue).toBe(3.00);
+ 
+      // Verifica diretamente no banco
+      const { data } = await supabase
+        .from("orders")
+        .select("payment_method, change_value")
+        .eq("id", result.id)
+        .single();
+ 
+      expect(data.payment_method).toBe("ESPECIE_COM_TROCO");
+      expect(Number(data.change_value)).toBe(3.00);
+    });
+ 
+    it("should create LOCAL order without payment_method (NULL in database)", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 50.00,
+        type: "LOCAL",
+        detail: "5",
+        orderLines: baseOrderLines,
+      };
+ 
+      const result = await createOrder(orderDTO, testEstablishmentId);
+ 
+      expect(result.paymentMethod).toBeUndefined();
+ 
+      // Verifica diretamente no banco que está NULL
+      const { data } = await supabase
+        .from("orders")
+        .select("payment_method")
+        .eq("id", result.id)
+        .single();
+ 
+      expect(data.payment_method).toBeNull();
+    });
+ 
+    it("should create LOCAL order with change_value as 0 by default", async () => {
+      const orderDTO: OrderRequestDTO = {
+        total: 50.00,
+        type: "LOCAL",
+        detail: "5",
+        orderLines: baseOrderLines,
+      };
+ 
+      const result = await createOrder(orderDTO, testEstablishmentId);
+ 
+      // Verifica diretamente no banco
+      const { data } = await supabase
+        .from("orders")
+        .select("change_value")
+        .eq("id", result.id)
+        .single();
+ 
+      expect(Number(data.change_value)).toBe(0);
+    });
+  });
+
+
+   // VALID CASES — updateOrder com pagamento
+  // ─────────────────────────────────────────────
+ 
+  describe("Valid Cases - updateOrder com formas de pagamento", () => {
+ 
+    it("should update LOCAL order adding payment method and save in database", async () => {
+      // Cria pedido LOCAL sem pagamento
+      const created = await createOrder({
+        total: 50.00,
+        type: "LOCAL",
+        detail: "5",
+        orderLines: baseOrderLines,
+      }, testEstablishmentId);
+ 
+      // Edita adicionando forma de pagamento
+      const updateDTO: OrderRequestDTO = {
+        id: created.id,
+        total: 50.00,
+        type: "LOCAL",
+        detail: "5",
+        orderLines: baseOrderLines,
+        paymentMethod: "PIX",
+      };
+ 
+      const result = await updateOrder(updateDTO);
+ 
+      expect(result.paymentMethod).toBe("PIX");
+ 
+      // Verifica no banco
+      const { data } = await supabase
+        .from("orders")
+        .select("payment_method")
+        .eq("id", created.id)
+        .single();
+ 
+      expect(data.payment_method).toBe("PIX");
+    });
+ 
+    it("should update payment method from PIX to CREDITO", async () => {
+      const created = await createOrder({
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "PIX",
+      }, testEstablishmentId);
+ 
+      const updateDTO: OrderRequestDTO = {
+        id: created.id,
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "CREDITO",
+      };
+ 
+      const result = await updateOrder(updateDTO);
+ 
+      expect(result.paymentMethod).toBe("CREDITO");
+    });
+ 
+    it("should update order adding ESPECIE_COM_TROCO and save change_value", async () => {
+      const created = await createOrder({
+        total: 27.00,
+        type: "LOCAL",
+        detail: "5",
+        orderLines: [{ menuItemId: mockMenuItemId, name: "Lanche", quantity: 1, price: 27.00 }],
+      }, testEstablishmentId);
+ 
+      const updateDTO: OrderRequestDTO = {
+        id: created.id,
+        total: 27.00,
+        type: "LOCAL",
+        detail: "5",
+        orderLines: [{ menuItemId: mockMenuItemId, name: "Lanche", quantity: 1, price: 27.00 }],
+        paymentMethod: "ESPECIE_COM_TROCO",
+        changeValue: 3.00,
+      };
+ 
+      const result = await updateOrder(updateDTO);
+ 
+      expect(result.paymentMethod).toBe("ESPECIE_COM_TROCO");
+      expect(result.changeValue).toBe(3.00);
+ 
+      // Verifica no banco
+      const { data } = await supabase
+        .from("orders")
+        .select("payment_method, change_value")
+        .eq("id", created.id)
+        .single();
+ 
+      expect(data.payment_method).toBe("ESPECIE_COM_TROCO");
+      expect(Number(data.change_value)).toBe(3.00);
+    });
+  });
+
+
+  });

--- a/tests/integration/orders/payment-method.test.ts
+++ b/tests/integration/orders/payment-method.test.ts
@@ -277,5 +277,53 @@ describe("Payment Method Integration", () => {
     });
   });
 
+   // VALID CASES — getOrderById com pagamento
+ 
+  describe("Valid Cases - getOrderById retorna paymentMethod e changeValue", () => {
+ 
+    it("should return paymentMethod when fetching order by id", async () => {
+      const created = await createOrder({
+        total: 50.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: baseOrderLines,
+        paymentMethod: "PIX",
+      }, testEstablishmentId);
+ 
+      const result = await getOrderById(created.id!);
+ 
+      expect(result.paymentMethod).toBe("PIX");
+    });
+ 
+    it("should return changeValue when fetching order with ESPECIE_COM_TROCO", async () => {
+      const created = await createOrder({
+        total: 27.00,
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: [{ menuItemId: mockMenuItemId, name: "Lanche", quantity: 1, price: 27.00 }],
+        paymentMethod: "ESPECIE_COM_TROCO",
+        changeValue: 3.00,
+      }, testEstablishmentId);
+ 
+      const result = await getOrderById(created.id!);
+ 
+      expect(result.paymentMethod).toBe("ESPECIE_COM_TROCO");
+      expect(result.changeValue).toBe(3.00);
+    });
+ 
+    it("should return paymentMethod as undefined for LOCAL order without payment", async () => {
+      const created = await createOrder({
+        total: 50.00,
+        type: "LOCAL",
+        detail: "5",
+        orderLines: baseOrderLines,
+      }, testEstablishmentId);
+ 
+      const result = await getOrderById(created.id!);
+ 
+      expect(result.paymentMethod).toBeUndefined();
+    });
+  });
+
 
   });

--- a/tests/unit/entities/payment-method.test.ts
+++ b/tests/unit/entities/payment-method.test.ts
@@ -73,6 +73,135 @@ describe("Payment Method Feature", () => {
     });
   
 
+    // UNIT TESTS — Change Calculation
 
+
+  describe("Change calculation (ESPECIE_COM_TROCO)", () => {
+
+    it("should calculate change correctly: total 27, change for 30 = 3", () => {
+      const total = 27;
+      const valorDigitado = 30;
+      const troco = Math.max(0, valorDigitado - total);
+      expect(troco).toBe(3);
+    });
+
+    it("should calculate change correctly: total 50, change for 100 = 50", () => {
+      const total = 50;
+      const valorDigitado = 100;
+      const troco = Math.max(0, valorDigitado - total);
+      expect(troco).toBe(50);
+    });
+
+    it("should return 0 when entered value equals total", () => {
+      const total = 50;
+      const valorDigitado = 50;
+      const troco = Math.max(0, valorDigitado - total);
+      expect(troco).toBe(0);
+    });
+
+    it("should not return negative change", () => {
+      const total = 50;
+      const valorDigitado = 30;
+      const troco = Math.max(0, valorDigitado - total);
+      expect(troco).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should store changeValue in order", () => {
+      const order = new PickupOrder({
+        customerName: "Maria",
+        orderLines: [{ menuItemId: "1", name: "Lanche", quantity: 1, price: 27 }],
+        paymentMethod: "ESPECIE_COM_TROCO",
+        changeValue: 3,
+      });
+      expect(order.changeValue).toBe(3);
+    });
+  });
+
+
+  // UNIT TESTS — toJSON()
+
+
+  describe("toJSON() with paymentMethod and changeValue", () => {
+
+    it("should include paymentMethod in toJSON()", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "PIX",
+      });
+      const json = order.toJSON();
+      expect(json.paymentMethod).toBe("PIX");
+    });
+
+    it("should include changeValue in toJSON()", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "ESPECIE_COM_TROCO",
+        changeValue: 3,
+      });
+      const json = order.toJSON();
+      expect(json.changeValue).toBe(3);
+    });
+
+    it("should return changeValue 0 in toJSON() when not provided", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "PIX",
+      });
+      const json = order.toJSON();
+      expect(json.changeValue).toBe(0);
+    });
+
+    it("should return paymentMethod undefined in toJSON() for LOCAL order without payment", () => {
+      const order = new LocalOrder({
+        tableNumber: "5",
+        orderLines: commonLines,
+      });
+      const json = order.toJSON();
+      expect(json.paymentMethod).toBeUndefined();
+    });
+  });
+
+  
+  // UNIT TESTS — fromDTO()
+  
+
+  describe("Order.fromDTO() with paymentMethod and changeValue", () => {
+
+    it("should map PIX paymentMethod correctly via fromDTO", () => {
+      const order = Order.fromDTO({
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: commonLines,
+        paymentMethod: "PIX",
+      });
+      expect(order.paymentMethod).toBe("PIX");
+    });
+
+    it("should map ESPECIE_COM_TROCO paymentMethod and changeValue via fromDTO", () => {
+      const order = Order.fromDTO({
+        type: "PICKUP",
+        detail: "João Silva",
+        orderLines: commonLines,
+        paymentMethod: "ESPECIE_COM_TROCO",
+        changeValue: 3,
+      });
+      expect(order.paymentMethod).toBe("ESPECIE_COM_TROCO");
+      expect(order.changeValue).toBe(3);
+    });
+
+    it("should create LOCAL order via fromDTO without paymentMethod", () => {
+      const order = Order.fromDTO({
+        type: "LOCAL",
+        detail: "5",
+        orderLines: commonLines,
+      });
+      expect(order.paymentMethod).toBeUndefined();
+      expect(order.changeValue).toBe(0);
+    });
+
+  });
 
 });

--- a/tests/unit/entities/payment-method.test.ts
+++ b/tests/unit/entities/payment-method.test.ts
@@ -1,0 +1,78 @@
+import { LocalOrder, PickupOrder, Order } from "@/lib/entities/order";
+ 
+describe("Payment Method Feature", () => {
+  const commonLines = [
+    { menuItemId: "1", name: "Pizza", quantity: 1, price: 50 },
+  ];
+
+  // TESTES UNITÁRIOS — Entidade Order
+
+    it("should create order with PIX paymentMethod", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "PIX",
+      });
+      expect(order.paymentMethod).toBe("PIX");
+    });
+
+        it("should create order with CREDITO paymentMethod", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "CREDITO",
+      });
+      expect(order.paymentMethod).toBe("CREDITO");
+    });
+
+        it("should create order with DEBITO paymentMethod", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "DEBITO",
+      });
+      expect(order.paymentMethod).toBe("DEBITO");
+    });
+    
+        it("should create order with ESPECIE_SEM_TROCO paymentMethod", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "ESPECIE_SEM_TROCO",
+      });
+      expect(order.paymentMethod).toBe("ESPECIE_SEM_TROCO");
+    });
+
+        it("should create order with ESPECIE_COM_TROCO paymentMethod and correct changeValue", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "ESPECIE_COM_TROCO",
+        changeValue: 3,
+      });
+      expect(order.paymentMethod).toBe("ESPECIE_COM_TROCO");
+      expect(order.changeValue).toBe(3);
+    });
+
+        it("should have changeValue as 0 by default when not provided", () => {
+      const order = new PickupOrder({
+        customerName: "João",
+        orderLines: commonLines,
+        paymentMethod: "PIX",
+      });
+      expect(order.changeValue).toBe(0);
+    });
+
+    it("should create LOCAL order without paymentMethod (payment informed later)", () => {
+      const order = new LocalOrder({
+        tableNumber: "5",
+        orderLines: commonLines,
+      });
+      expect(order.paymentMethod).toBeUndefined();
+      expect(order.changeValue).toBe(0);
+    });
+  
+
+
+
+});


### PR DESCRIPTION
Adicionado suporte a formas de pagamento nos pedidos do sistema.

Formas de pagamento
- Pix
- Crédito
- Débito
- Espécie sem troco
- Espécie com troco (com cálculo automático de troco)

 Regras de negócio
- Pedidos de **retirada**: forma de pagamento obrigatória na criação
- Pedidos **locais**: forma de pagamento informada na edição. O botão Finalizar fica bloqueado até que seja informada

Testes adicionados
- Testes unitários: `tests/unit/entities/payment-method.test.ts`
- Testes de integração: `tests/integration/orders/payment-method.test.ts`
- Testes E2E: `tests/e2e/order/payment-method.spec.ts`