### PR TITLE
Feat/pending orders

### DIFF
--- a/app/actions/order-actions.ts
+++ b/app/actions/order-actions.ts
@@ -110,8 +110,33 @@ export async function getTodayOrders(establishment_id: string): Promise<any> {
     .lte("date", end)
 
   if (error) {
-    console.error("Erro Supabase (getOrders):", error);
+    console.error("Erro Supabase (getTodayOrders):", error);
     throw new Error("Erro ao buscar pedidos.");
+  }
+
+  return data.map((o: any) => adjustOrderLines(o));
+}
+
+export async function getOldPendingOrders(establishment_id?: string): Promise<any> {
+  const supabase = await createClient();
+
+  const actualId = establishment_id && establishment_id !== "" 
+    ? establishment_id 
+    : await getEstablishmentId();
+
+  const today = new Date();
+  const startOfToday = new Date(today.setHours(0, 0, 0, 0)).toISOString();
+
+  const { data, error } = await supabase
+    .from("orders")
+    .select("*, order_lines(*)")
+    .eq("establishment_id", actualId)
+    .eq("status", "OPEN")
+    .lt("date", startOfToday);
+
+  if (error) {
+    console.error("Erro Supabase (getOldPendingOrders):", error);
+    throw new Error("Erro ao buscar pedidos pendentes antigos.");
   }
 
   return data.map((o: any) => adjustOrderLines(o));
@@ -287,6 +312,7 @@ function adjustOrderLines(orderData: any) {
     deliveryFee: orderData.delivery_fee,
     estimatedTime: orderData.estimated_time,
     paymentMethod: orderData.payment_method,
-    changeValue: orderData.change_value
+    changeValue: orderData.change_value,
+    date: orderData.date
   }).toJSON();
 }

--- a/app/actions/order-actions.ts
+++ b/app/actions/order-actions.ts
@@ -25,6 +25,8 @@ export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId
   const supabase = await createClient();
   const establishment_id = testEstablishmentId ? testEstablishmentId : await getEstablishmentId();
 
+  const currentDate = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Sao_Paulo' });
+
   const { data, error } = await supabase
     .from("orders")
     .insert({
@@ -37,8 +39,9 @@ export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId
       estimated_time: orderEntity.estimatedTime ?? 0,
       payment_method: orderDTO.paymentMethod,
       change_value: orderDTO.changeValue ?? 0,
+      date: currentDate
     })
-    .select("id, daily_seq")
+    .select("id, daily_seq, date")
     .single();
 
   if (error) {
@@ -68,6 +71,7 @@ export async function createOrder(orderDTO: OrderRequestDTO, testEstablishmentId
 
   orderEntity.id = data.id;
   orderEntity.dailySeq = data.daily_seq;
+  orderEntity.date = data.date;
   orderEntity.paymentMethod = orderDTO.paymentMethod;
   orderEntity.changeValue = orderDTO.changeValue ?? 0;
 

--- a/app/auth/orders/page.tsx
+++ b/app/auth/orders/page.tsx
@@ -49,7 +49,7 @@ export default async function OrdersPage() {
   const safeUser =
     user && typeof user.toJSON === "function" ? user.toJSON() : user ?? {};
 
-  const serverDate = new Date().toISOString().split('T')[0];
+  const serverDate = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Sao_Paulo' });
 
   return (
     <AppShell

--- a/app/auth/orders/page.tsx
+++ b/app/auth/orders/page.tsx
@@ -49,6 +49,8 @@ export default async function OrdersPage() {
   const safeUser =
     user && typeof user.toJSON === "function" ? user.toJSON() : user ?? {};
 
+  const serverDate = new Date().toISOString().split('T')[0];
+
   return (
     <AppShell
       currentPage="Painel de Pedidos"
@@ -57,10 +59,10 @@ export default async function OrdersPage() {
     >
       <OrdersDashboard
         orders={orders ?? []}
-        categories={categories ?? []
-        }
+        categories={categories ?? []}
         menuItems={menuItems ?? []}
+        serverDate={serverDate}
       />
     </AppShell>
   );
-}
+  }

--- a/app/auth/orders/types.ts
+++ b/app/auth/orders/types.ts
@@ -18,6 +18,8 @@ export type OrderDTO = {
   tableNumber?: string;
   customerName?: string;
   orderLines: OrderLineDTO[];
+  date?: string;
+  dailySeq?: number;
 };
 
 export interface OrderCardProps {

--- a/components/organisms/order-card.tsx
+++ b/components/organisms/order-card.tsx
@@ -14,9 +14,22 @@ export function OrderCard({ order, onEdit, onDelete, onFinish, onReopen }: Order
     >
       <div className="flex justify-between items-start mb-2">
         <div>
-          <span className="text-xs font-black text-blue-600 bg-blue-50 px-2 py-1 rounded-md border border-blue-100">
-            {order.code}
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-black text-blue-600 bg-blue-50 px-2 py-1 rounded-md border border-blue-100">
+              {order.code}
+            </span>
+            {order.date && (
+              <span className="text-[10px] text-gray-400 font-medium">
+                {(() => {
+                  const parts = order.date.split('-');
+                  if (parts.length === 3) {
+                    return `${parts[2]}/${parts[1]}`;
+                  }
+                  return order.date;
+                })()}
+              </span>
+            )}
+          </div>
           <p className="text-sm font-bold text-gray-800 mt-2.5">
             {order.type === "LOCAL" ? `Mesa: ${order.detail}` : `Cliente: ${order.detail}`}
           </p>

--- a/components/organisms/order-card.tsx
+++ b/components/organisms/order-card.tsx
@@ -21,11 +21,13 @@ export function OrderCard({ order, onEdit, onDelete, onFinish, onReopen }: Order
             {order.date && (
               <span className="text-[10px] text-gray-400 font-medium">
                 {(() => {
-                  const parts = order.date.split('-');
+                  // Pega apenas a parte da data (YYYY-MM-DD) e ignora o resto
+                  const cleanDate = order.date.split('T')[0];
+                  const parts = cleanDate.split('-');
                   if (parts.length === 3) {
                     return `${parts[2]}/${parts[1]}`;
                   }
-                  return order.date;
+                  return cleanDate;
                 })()}
               </span>
             )}

--- a/components/organisms/order-column.tsx
+++ b/components/organisms/order-column.tsx
@@ -29,7 +29,12 @@ export function OrderColumn({ title, orders, status, serverDate, ...actions }: O
     return (a.dailySeq || 0) - (b.dailySeq || 0);
   });
 
-  todayOrders.sort((a, b) => (a.dailySeq || 0) - (b.dailySeq || 0));
+  todayOrders.sort((a, b) => {
+    if (status === "CLOSED") {
+      return (b.dailySeq || 0) - (a.dailySeq || 0);
+    }
+    return (a.dailySeq || 0) - (b.dailySeq || 0);
+  });
 
   const hasBacklog = status === "OPEN" && backlogOrders.length > 0;
 
@@ -72,6 +77,12 @@ export function OrderColumn({ title, orders, status, serverDate, ...actions }: O
                 <OrderCard order={order} {...actions} />
               </div>
             ))}
+            <button
+              onClick={() => setShowBacklog(false)}
+              className="w-full py-2 text-[10px] font-black text-orange-600 uppercase tracking-widest bg-orange-50 hover:bg-orange-100 rounded-xl transition-all border border-orange-100/50"
+            >
+              Esconder Pendências
+            </button>
           </div>
         )}
 

--- a/components/organisms/order-column.tsx
+++ b/components/organisms/order-column.tsx
@@ -1,5 +1,7 @@
+import React, { useState } from "react";
 import { OrderDTO } from "@/app/auth/orders/types";
 import { OrderCard } from "./order-card";
+import { History } from "lucide-react";
 
 interface OrderColumnProps {
   title: string;
@@ -9,26 +11,70 @@ interface OrderColumnProps {
   onDelete?: (id: string) => void;
   onFinish?: (id: string) => void;
   onReopen?: (id: string) => void;
+  serverDate: string;
 }
 
-export function OrderColumn({ title, orders, status, ...actions }: OrderColumnProps) {
+export function OrderColumn({ title, orders, status, serverDate, ...actions }: OrderColumnProps) {
+  const [showBacklog, setShowBacklog] = useState(false);
+
   const filteredOrders = orders.filter(o => o.status === status);
+  const today = serverDate;
+
+  const backlogOrders = filteredOrders
+    .filter(o => o.date && o.date < today)
+    .sort((a, b) => (a.date || "").localeCompare(b.date || "") || (a.dailySeq || 0) - (b.dailySeq || 0));
+
+  const todayOrders = filteredOrders
+    .filter(o => !o.date || o.date >= today)
+    .sort((a, b) => (a.dailySeq || 0) - (b.dailySeq || 0));
+
+  const hasBacklog = status === "OPEN" && backlogOrders.length > 0;
 
   return (
     <div className="bg-gray-50/50 p-0 md:p-4 rounded-2xl border border-gray-100 flex flex-col h-full" data-testid={`order-column-${status}`}>
       <div className="flex items-center justify-between mb-4 px-4 mt-4 md:mt-0 md:px-1">
         <h2 className="font-bold text-gray-700 flex items-center gap-2">
           {title}
-          <span className="bg-gray-200 text-gray-600 text-[10px] px-2 py-0.5 rounded-full">
-            {filteredOrders.length}
-          </span>
+          {hasBacklog ? (
+            <button
+              onClick={() => setShowBacklog(!showBacklog)}
+              className={`text-xs px-2.5 py-1 rounded-full font-black transition-all shadow-sm flex items-center gap-1.5 shrink-0 hover:scale-105 active:scale-95 ${
+                showBacklog 
+                  ? "bg-orange-500 text-white" 
+                  : "bg-orange-500 text-white animate-pulse"
+              }`}
+              title="Clique para ver pendências de dias anteriores"
+            >
+              <History className="size-3.5" />
+              {filteredOrders.length}
+            </button>
+          ) : (
+            <span className="bg-gray-200 text-gray-600 text-xs px-2.5 py-1 rounded-full font-bold shrink-0">
+              {status === "OPEN" ? filteredOrders.length : todayOrders.length}
+            </span>
+          )}
         </h2>
       </div>
       <div className="flex-1 overflow-y-auto px-0 md:pr-1">
-        {filteredOrders.length === 0 ? (
+        {hasBacklog && showBacklog && (
+          <div className="mb-4 space-y-4 pb-4 border-b border-orange-100">
+            {backlogOrders.map(order => (
+              <div key={order.id} className="relative">
+                <div className="absolute -top-1.5 right-2 z-10">
+                  <span className="bg-orange-500 text-white text-[9px] font-black px-2 py-0.5 rounded-full shadow-sm uppercase">
+                    Pendente
+                  </span>
+                </div>
+                <OrderCard order={order} {...actions} />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {todayOrders.length === 0 && (!hasBacklog || !showBacklog) ? (
           <p className="text-center text-sm text-gray-400 py-10">Nenhum pedido aqui</p>
         ) : (
-          filteredOrders.map(order => (
+          todayOrders.map(order => (
             <OrderCard key={order.id} order={order} {...actions} />
           ))
         )}

--- a/components/organisms/order-column.tsx
+++ b/components/organisms/order-column.tsx
@@ -20,15 +20,19 @@ export function OrderColumn({ title, orders, status, serverDate, ...actions }: O
   const filteredOrders = orders.filter(o => o.status === status);
   const today = serverDate;
 
-  const backlogOrders = filteredOrders
-    .filter(o => o.date && o.date < today)
-    .sort((a, b) => (a.date || "").localeCompare(b.date || "") || (a.dailySeq || 0) - (b.dailySeq || 0));
+  const backlogOrders = filteredOrders.filter(order => order.date && order.date < today);
+  const todayOrders = filteredOrders.filter(order => !order.date || order.date >= today);
 
-  const todayOrders = filteredOrders
-    .filter(o => !o.date || o.date >= today)
-    .sort((a, b) => (a.dailySeq || 0) - (b.dailySeq || 0));
+  backlogOrders.sort((a, b) => {
+    const dateComparison = (a.date || "").localeCompare(b.date || "");
+    if (dateComparison !== 0) return dateComparison;
+    return (a.dailySeq || 0) - (b.dailySeq || 0);
+  });
+
+  todayOrders.sort((a, b) => (a.dailySeq || 0) - (b.dailySeq || 0));
 
   const hasBacklog = status === "OPEN" && backlogOrders.length > 0;
+
 
   return (
     <div className="bg-gray-50/50 p-0 md:p-4 rounded-2xl border border-gray-100 flex flex-col h-full" data-testid={`order-column-${status}`}>

--- a/components/organisms/orders-dashboard.tsx
+++ b/components/organisms/orders-dashboard.tsx
@@ -190,7 +190,7 @@ export default function OrdersDashboard({
             </TabsTrigger>
             <TabsTrigger 
               value="CLOSED" 
-              className="rounded-lg font-bold data-[state=active]:bg-white data-[state=active]:text-green-600"
+              className="rounded-lg font-bold data-[state=active]:bg-white data-[state=active]:text-blue-600"
             >
               Finalizados
             </TabsTrigger>

--- a/components/organisms/orders-dashboard.tsx
+++ b/components/organisms/orders-dashboard.tsx
@@ -18,6 +18,7 @@ import {
   updateOrder,
   updateToClosedOrder,
   updateToOpenOrder,
+  getOldPendingOrders,
   OrderRequestDTO,
 } from "@/app/actions/order-actions";
 import { MenuItem } from "@/app/actions/menu-item-actions";
@@ -28,12 +29,14 @@ interface OrdersDashboardProps {
   menuItems: MenuItem[];
   categories: Category[];
   orders: OrderDTO[];
+  serverDate: string;
 }
 
 export default function OrdersDashboard({
   menuItems,
   categories,
   orders: initialOrders,
+  serverDate,
 }: OrdersDashboardProps) {
   const [orders, setOrders] = useState<OrderDTO[]>(initialOrders);
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
@@ -42,6 +45,24 @@ export default function OrdersDashboard({
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { toast } = useToast();
+
+  React.useEffect(() => {
+    const fetchOldOrders = async () => {
+      try {
+        const oldOrders = await getOldPendingOrders("");
+        if (oldOrders.length > 0) {
+          setOrders((prev) => {
+            const existingIds = prev.map(o => o.id);
+            const newOldOrders = oldOrders.filter((o: any) => !existingIds.includes(o.id));
+            return [...newOldOrders, ...prev];
+          });
+        }
+      } catch (error) {
+        console.error("Dashboard: Erro ao buscar pedidos antigos:", error);
+      }
+    };
+    fetchOldOrders();
+  }, []);
 
   const handleCreateOrder = async (newOrder: OrderRequestDTO) => {
     try {
@@ -183,6 +204,7 @@ export default function OrdersDashboard({
               onEdit={handleEditClick}
               onDelete={handleDeleteClick}
               onFinish={handleFinishOrder}
+              serverDate={serverDate}
             />
           </TabsContent>
           <TabsContent value="CLOSED" className="mt-0 outline-none px-2">
@@ -191,12 +213,12 @@ export default function OrdersDashboard({
               orders={orders}
               status="CLOSED"
               onReopen={handleReopenOrder}
+              serverDate={serverDate}
             />
           </TabsContent>
         </Tabs>
       </div>
 
-      {/* Layout Desktop com Colunas Lado a Lado */}
       <div className="hidden lg:grid grid-cols-2 gap-8 h-[calc(100vh-200px)] px-4">
         <OrderColumn
           title="PEDIDOS ABERTOS"
@@ -205,12 +227,14 @@ export default function OrdersDashboard({
           onEdit={handleEditClick}
           onDelete={handleDeleteClick}
           onFinish={handleFinishOrder}
+          serverDate={serverDate}
         />
         <OrderColumn
           title="FINALIZADOS"
           orders={orders}
           status="CLOSED"
           onReopen={handleReopenOrder}
+          serverDate={serverDate}
         />
       </div>
 

--- a/lib/entities/order.ts
+++ b/lib/entities/order.ts
@@ -116,6 +116,7 @@ export abstract class Order {
     dailySeq?: number;
     paymentMethod?: PaymentMethod;
     changeValue?: number;
+    date?: string;
   }): Order {
     switch (dto.type) {
       case "LOCAL":
@@ -127,7 +128,8 @@ export abstract class Order {
           estimatedTime: dto.estimatedTime,
           dailySeq: dto.dailySeq,
           paymentMethod: dto.paymentMethod,
-          changeValue: dto.changeValue
+          changeValue: dto.changeValue,
+          date: dto.date
         });
       case "PICKUP":
         return new PickupOrder({
@@ -139,6 +141,7 @@ export abstract class Order {
           dailySeq: dto.dailySeq,
           paymentMethod: dto.paymentMethod,
           changeValue: dto.changeValue,
+          date: dto.date
         });
       case "DELIVERY":
         return new DeliveryOrder({
@@ -151,6 +154,7 @@ export abstract class Order {
           dailySeq: dto.dailySeq,
           paymentMethod: dto.paymentMethod,
           changeValue: dto.changeValue,
+          date: dto.date
         });
       default:
         throw new Error("Tipo de pedido inválido.");

--- a/tests/e2e/order/backlog-recovery.spec.ts
+++ b/tests/e2e/order/backlog-recovery.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Order Backlog Recovery', () => {
+
+  test.beforeEach(async ({ page }) => {
+    // Login padrão do projeto
+    await page.goto('http://localhost:3000/login');
+    await page.getByRole('textbox', { name: /e-mail/i }).fill('usuario@teste.com');
+    await page.getByRole('textbox', { name: /senha/i }).fill('senhatesteA1');
+    
+    // Clica e aguarda a navegação de forma mais robusta
+    await Promise.all([
+      page.waitForURL('**/auth/orders**', { timeout: 30000 }),
+      page.locator('button.bg-blue-600').click(),
+    ]);
+
+    await page.waitForTimeout(1000);
+  });
+
+  test('should toggle pending orders visibility using the counter button', async ({ page }) => {
+    // 1. Localiza a coluna de pedidos abertos que está visível (evita erro de duplicidade mobile/desktop)
+    const openColumn = page.locator('[data-testid="order-column-OPEN"]').filter({ visible: true }).first();
+    await expect(openColumn).toBeVisible();
+
+    // 2. Verifica se o contador está no estado de "pendência" (laranja e pulsante)
+    const backlogButton = openColumn.locator('button.bg-orange-500');
+    
+    if (await backlogButton.isVisible()) {
+      // 3. Valida se o botão tem a classe de pulso
+      await expect(backlogButton).toHaveClass(/animate-pulse/);
+
+      // 4. Clica no contador para abrir as pendências
+      await backlogButton.click();
+
+      // 5. Verifica se a seção de "Pendências" apareceu (flexível com regex)
+      const backlogSection = page.getByText(/Pendência/i).first();
+      await expect(backlogSection).toBeVisible();
+
+      // 6. Verifica se o badge "Pendente" aparece em algum card
+      const pendingBadge = page.locator('span:has-text("Pendente")').first();
+      await expect(pendingBadge).toBeVisible();
+
+      // 7. Clica no botão "Esconder Pendências" ao final da lista
+      const hideButton = page.getByRole('button', { name: /Esconder Pendências/i });
+      await expect(hideButton).toBeVisible();
+      await hideButton.click();
+
+      // 8. Valida que a seção de pendências foi escondida
+      await expect(backlogSection).not.toBeVisible();
+    } else {
+      // Se não houver pendências no banco de teste, validamos o contador normal
+      const normalCounter = openColumn.locator('span.bg-gray-200');
+      await expect(normalCounter).toBeVisible();
+    }
+  });
+
+  test('should display date on order cards', async ({ page }) => {
+    const orderCard = page.locator('[data-testid="order-card"]').first();
+    
+    if (await orderCard.isVisible()) {
+      // Procura pelo padrão de data XX/XX (ex: 10/05)
+      const dateText = orderCard.locator('span', { hasText: /^\d{2}\/\d{2}$/ });
+      await expect(dateText).toBeVisible();
+    }
+  });
+});

--- a/tests/integration/orders/read.test.ts
+++ b/tests/integration/orders/read.test.ts
@@ -1,4 +1,4 @@
-import { createOrder, getOrders, getOrderById, OrderRequestDTO, getOldPendingOrders } from "@/app/actions/order-actions";
+import { createOrder, getOrders, getOrderById, OrderRequestDTO, getOldPendingOrders, getTodayOrders } from "@/app/actions/order-actions";
 import { createClient } from "@/utils/supabase/server";
 
 describe("Orders READ Integration", () => {
@@ -55,34 +55,62 @@ describe("Orders READ Integration", () => {
       expect(data.type).toBe("LOCAL");
     });
 
-    it("should retrieve old pending orders (backlog)", async () => {
-      const data = await getOldPendingOrders(testEstablishmentId);
-      expect(Array.isArray(data)).toBe(true);
-    });
-
-    it("should NOT retrieve old orders that are already CLOSED in backlog", async () => {
-      const supabase = await createClient();
+    it("should retrieve old pending orders (backlog) with correct mapping", async () => {
+      const client = await createClient();
       const yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);
       const yesterdayStr = yesterday.toLocaleDateString('en-CA');
 
-      // Cria um pedido de ontem já FECHADO
-      const { data: closedOrder } = await supabase.from("orders").insert({
+      const { data: oldOrder } = await client.from("orders").insert({
         establishment_id: testEstablishmentId,
-        total: 10,
+        total: 100,
         type: "LOCAL",
-        status: "CLOSED",
-        detail: "Mesa 99",
+        status: "OPEN",
+        detail: "Mesa Velha",
         date: yesterdayStr
       }).select("id").single();
 
+      if (!oldOrder) throw new Error("Erro ao criar pedido antigo");
+
+      await client.from("order_lines").insert({
+        order_id: oldOrder.id,
+        menu_item_id: mockMenuItemId,
+        name: "Pizza Antiga",
+        price: 100,
+        quantity: 1
+      });
+
       const backlog = await getOldPendingOrders(testEstablishmentId);
-      const found = backlog.find((o: any) => o.id === closedOrder.id);
+      const found = backlog.find((o: any) => o.id === oldOrder.id);
       
+      expect(found).toBeDefined();
+      expect(found.date).toBe(yesterdayStr);
+      expect(found.orderLines[0].menuItemId).toBe(mockMenuItemId);
+
+      await client.from("orders").delete().eq("id", oldOrder.id);
+    });
+
+    it("should ENSURE today's list does NOT contain old orders (No Duplicates)", async () => {
+      const client = await createClient();
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toLocaleDateString('en-CA');
+
+      const { data: pastOrder } = await client.from("orders").insert({
+        establishment_id: testEstablishmentId,
+        total: 50,
+        type: "LOCAL",
+        status: "OPEN",
+        detail: "Mesa Passada",
+        date: yesterdayStr
+      }).select("id").single();
+
+      const todayOrders = await getTodayOrders(testEstablishmentId);
+      const found = todayOrders.find((o: any) => o.id === pastOrder?.id);
+
       expect(found).toBeUndefined();
 
-      // Limpeza
-      await supabase.from("orders").delete().eq("id", closedOrder.id);
+      if (pastOrder) await client.from("orders").delete().eq("id", pastOrder.id);
     });
 
     it("should NOT retrieve orders from OTHER establishments in backlog", async () => {

--- a/tests/integration/orders/read.test.ts
+++ b/tests/integration/orders/read.test.ts
@@ -1,4 +1,4 @@
-import { createOrder, getOrders, getOrderById, OrderRequestDTO } from "@/app/actions/order-actions";
+import { createOrder, getOrders, getOrderById, OrderRequestDTO, getOldPendingOrders } from "@/app/actions/order-actions";
 import { createClient } from "@/utils/supabase/server";
 
 describe("Orders READ Integration", () => {
@@ -53,6 +53,42 @@ describe("Orders READ Integration", () => {
       expect(data.id).toBe(testOrderId1);
       expect(data.total).toBe(50.75);
       expect(data.type).toBe("LOCAL");
+    });
+
+    it("should retrieve old pending orders (backlog)", async () => {
+      const data = await getOldPendingOrders(testEstablishmentId);
+      expect(Array.isArray(data)).toBe(true);
+    });
+
+    it("should NOT retrieve old orders that are already CLOSED in backlog", async () => {
+      const supabase = await createClient();
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toLocaleDateString('en-CA');
+
+      // Cria um pedido de ontem já FECHADO
+      const { data: closedOrder } = await supabase.from("orders").insert({
+        establishment_id: testEstablishmentId,
+        total: 10,
+        type: "LOCAL",
+        status: "CLOSED",
+        detail: "Mesa 99",
+        date: yesterdayStr
+      }).select("id").single();
+
+      const backlog = await getOldPendingOrders(testEstablishmentId);
+      const found = backlog.find((o: any) => o.id === closedOrder.id);
+      
+      expect(found).toBeUndefined();
+
+      // Limpeza
+      await supabase.from("orders").delete().eq("id", closedOrder.id);
+    });
+
+    it("should NOT retrieve orders from OTHER establishments in backlog", async () => {
+      const otherEstablishmentId = "00000000-0000-0000-0000-000000000000";
+      const backlog = await getOldPendingOrders(otherEstablishmentId);
+      expect(backlog.length).toBe(0);
     });
   });
 

--- a/tests/unit/entities/order.test.ts
+++ b/tests/unit/entities/order.test.ts
@@ -201,11 +201,48 @@ describe("Order Entity Hierarchy", () => {
       expect((order as DeliveryOrder).deliveryFee).toBe(15);
     });
 
+    it("should preserve date from DTO", () => {
+      const historicalDate = "2024-01-01";
+      const order = Order.fromDTO({
+        type: "LOCAL",
+        detail: "10",
+        orderLines: commonLines,
+        date: historicalDate,
+      });
+      expect(order.date).toBe(historicalDate);
+    });
+
+    it("should use default current date if DTO date is missing", () => {
+      const order = Order.fromDTO({
+        type: "LOCAL",
+        detail: "10",
+        orderLines: commonLines,
+      });
+      expect(order.date).toBeDefined();
+      expect(typeof order.date).toBe("string");
+      // Verifica se a data gerada contém o ano atual (formato ISO)
+      expect(order.date).toContain(new Date().getFullYear().toString());
+    });
+
     it("should throw error for invalid type", () => {
       expect(() => Order.fromDTO({
         type: "INVALID" as any,
         orderLines: commonLines,
       })).toThrow("Tipo de pedido inválido.");
+    });
+  });
+
+  describe("Order Sorting Logic", () => {
+    it("should correctly identify older dates", () => {
+      const today = "2024-05-10";
+      const yesterday = "2024-05-09";
+      const backlog = ["2024-05-05", "2024-05-09", "2024-05-01"];
+      
+      const sorted = [...backlog].sort((a, b) => a.localeCompare(b));
+      
+      expect(sorted[0]).toBe("2024-05-01");
+      expect(sorted[1]).toBe("2024-05-05");
+      expect(sorted[2]).toBe("2024-05-09");
     });
   });
 });


### PR DESCRIPTION
1 # Recuperação de Pedidos Pendentes
    2
    3 ## 📝 Descrição
    4 Este PR implementa a funcionalidade de recuperação de pedidos que ficaram abertos em dias anteriores
      (Backlog). Agora, o sistema identifica automaticamente essas pendências e fornece uma interface discreta
      para resolução.
    5
    6 ## Mudanças
    7 - **Lógica de Dados**: Nova Server Action `getOldPendingOrders` e suporte a datas históricas na entidade
      `Order`.
    8 - **Sincronia**: Uso da data do servidor (`serverDate`) para evitar erros de fuso horário local.
    9 - **UI Inteligente**:
   10   - Contador de pedidos agora pulsa em **Laranja** quando há pendências de dias passados.
   11   - Gaveta de histórico expansível ao clicar no próprio contador.
   12   - Exibição de data (`DD/MM`) nos cards de pedido.
   13   - Botão "Esconder Pendências" ao final da lista para melhorar a usabilidade mobile.